### PR TITLE
Performance tweaks

### DIFF
--- a/src/components/Hyperchat.svelte
+++ b/src/components/Hyperchat.svelte
@@ -50,14 +50,14 @@
     messagesAction: Chat.MessagesAction, isInitial: boolean
   ) => {
     if (!isAtBottom) return;
-    // Filter out initial messages on replays that aren't negative timestamped
-    messageActions.push(...(
-      isInitial && isReplay
-        ? messagesAction.messages.filter(
-          (a) => a.message.timestamp.startsWith('-')
-        )
-        : messagesAction.messages
-    ));
+    // On replays' initial data, only show messages with negative timestamp
+    if (isInitial && isReplay) {
+      messageActions.push(...messagesAction.messages.filter(
+        (a) => a.message.timestamp.startsWith('-')
+      ));
+    } else {
+      messageActions.push(...messagesAction.messages);
+    }
     if (!isInitial) checkTruncateMessages();
   };
 

--- a/src/components/Hyperchat.svelte
+++ b/src/components/Hyperchat.svelte
@@ -47,9 +47,9 @@
     messageActions = messageActions;
   };
 
-  const newMessage = (messageAction: Chat.MessageAction) => {
+  const newMessages = (messagesAction: Chat.MessagesAction) => {
     if (!isAtBottom) return;
-    messageActions.push(messageAction);
+    messageActions.push(...messagesAction.messages);
     messageActions = messageActions;
   };
 
@@ -75,8 +75,8 @@
 
   const onChatAction = (action: Chat.Actions) => {
     switch (action.type) {
-      case 'message':
-        newMessage(action);
+      case 'messages':
+        newMessages(action);
         break;
       case 'bonk':
         onBonk(action.bonk);

--- a/src/ts/chat-utils.ts
+++ b/src/ts/chat-utils.ts
@@ -36,6 +36,6 @@ export const isValidFrameInfo = (f: Chat.UncheckedFrameInfo, port?: Chat.Port): 
   return check;
 };
 
-const actionTypes = new Set(['message', 'bonk', 'delete', 'pin', 'unpin', 'playerProgress', 'forceUpdate']);
+const actionTypes = new Set(['messages', 'bonk', 'delete', 'pin', 'unpin', 'playerProgress', 'forceUpdate']);
 export const responseIsAction = (r: Chat.BackgroundResponse): r is Chat.Actions =>
   actionTypes.has(r.type);

--- a/src/ts/queue.ts
+++ b/src/ts/queue.ts
@@ -102,6 +102,7 @@ export function ytcQueue(isReplay = false): YtcQueue {
       if (!message) return;
       messages.push(message);
     }
+    if (messages.length < 1) return;
     latestAction.set({ type: 'messages', messages });
   };
 

--- a/src/ts/queue.ts
+++ b/src/ts/queue.ts
@@ -96,13 +96,13 @@ export function ytcQueue(isReplay = false): YtcQueue {
    * `extraCondition` returns false.
    */
   const pushQueueToStore = (extraCondition: QueueCondition): void => {
-    const messages: Chat.MessageAction[];
+    const messages: Chat.MessageAction[] = [];
     while (messageQueue.front() && extraCondition(messageQueue)) {
       const message = messageQueue.pop();
       if (!message) return;
       messages.push(message);
     }
-    latestAction.set({ type: 'messages', messages })
+    latestAction.set({ type: 'messages', messages });
   };
 
   const isScrubbedOrSkipped = (time: number): boolean => {
@@ -230,7 +230,7 @@ export function ytcQueue(isReplay = false): YtcQueue {
       }, []);
 
     if (setInitial) {
-      initialData = [...messageActions, ...misc];
+      initialData = [{ type: 'messages', messages: messageActions }, ...misc];
       return;
     }
 

--- a/src/ts/queue.ts
+++ b/src/ts/queue.ts
@@ -96,11 +96,13 @@ export function ytcQueue(isReplay = false): YtcQueue {
    * `extraCondition` returns false.
    */
   const pushQueueToStore = (extraCondition: QueueCondition): void => {
+    const messages: Chat.MessageAction[];
     while (messageQueue.front() && extraCondition(messageQueue)) {
       const message = messageQueue.pop();
       if (!message) return;
-      latestAction.set(message);
+      messages.push(message);
     }
+    latestAction.set({ type: 'messages', messages })
   };
 
   const isScrubbedOrSkipped = (time: number): boolean => {
@@ -217,7 +219,6 @@ export function ytcQueue(isReplay = false): YtcQueue {
           m.showtime += currentChunkDelay;
         }
         const messageAction: Chat.MessageAction = {
-          type: 'message',
           message: m
         };
         processDeleted(messageAction, bonks, deletions);

--- a/src/ts/typings/chat.d.ts
+++ b/src/ts/typings/chat.d.ts
@@ -10,7 +10,7 @@ declare namespace Chat {
 
   interface MessagesAction {
     type: 'messages';
-    messages: MessageAction[]
+    messages: MessageAction[];
   }
 
   interface BonkAction {

--- a/src/ts/typings/chat.d.ts
+++ b/src/ts/typings/chat.d.ts
@@ -4,9 +4,13 @@ declare namespace Chat {
   }
 
   interface MessageAction {
-    type: 'message';
     message: Ytc.ParsedMessage;
     deleted?: MessageDeletedObj;
+  }
+
+  interface MessagesAction {
+    type: 'messages';
+    messages: MessageAction[]
   }
 
   interface BonkAction {
@@ -29,7 +33,7 @@ declare namespace Chat {
     messages: MessageAction[];
   }
 
-  type Actions = MessageAction | BonkAction | DeleteAction | Ytc.ParsedMisc | PlayerProgressAction | ForceUpdate;
+  type Actions = MessagesAction | BonkAction | DeleteAction | Ytc.ParsedMisc | PlayerProgressAction | ForceUpdate;
 
   interface UncheckedFrameInfo {
     tabId: number | undefined;


### PR DESCRIPTION
Various tweaks that should help with HyperChat performance, especially with slower hardware:

- Queued messages from the YTC JSON parser are sent in 250ms batches, instead of on each individual message. Reduces the frequency of svelte array updates.
This is a breaking change in the background messaging API that will require an update on LTL side (LiveTL/LiveTL@9893b3c).
- Chat history size is reduced from 250 to 150. Nobody needs to scroll that much anyway. 150 is based on Twitch chat.
- Message truncation is changed from running on a timer to being based on chat history size. Truncation is only done if the amount of messages is 20 larger than chat history size, which will then be spliced down to the chat history size. Helps spread DOM operations into smaller chunks during heavy chat traffic.

From my testing on an Intel Atom x5-Z8350 tablet PC, these tweaks saw a pretty consistent 5-15% lower CPU usage compared to v2.0.1 on chat-heavy streams (such as HoloX debut streams), which is honestly pretty good considering how shit this PC is. Performance during slow chats is basically similar with before, and of course these changes barely make a difference on modern hardware.

As a side note, I also tested using a variation of the double rotating array Kento used in Vue HC (2297dd3), and plain array splicing still performed better, not to mention being much, much simpler code-wise.

Also another fun fact, HyperChat v1.3.4 actually performs *WORSE* than YTC during Chloe's debut, at least on this shitty PC. Good thing we jumped off that ship already lol.