### PR TITLE
Only add content_security_policy on dev builds

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -4,7 +4,6 @@
   "homepage_url": "https://livetl.app/en/hyperchat/",
   "description": "YouTube chat, but it's fast and sleek!",
   "version": "42.0.69",
-  "content_security_policy": "script-src 'self' https://www.youtube.com 'unsafe-eval'; object-src 'self'",
   "permissions": [
   ],
   "icons": {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -25,6 +25,7 @@ const transformManifest = (manifestString, version, prod, isChrome = false) => {
     version
   };
   if (isChrome) newManifest.incognito = 'split';
+  if (!prod) newManifest.content_security_policy = 'script-src \'self\' \'unsafe-eval\'; object-src \'self\'';
   return JSON.stringify(newManifest, null, prod ? 0 : 2);
 };
 


### PR DESCRIPTION
Using remote sources and `unsafe-eval` are not allowed by Mozilla's Add-on Policies, so this removes it from production builds and only adds it to development builds where webpack source maps requires eval.