### PR TITLE
Use extension storage

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "svelte-loader": "^3.1.2",
     "svelte-preprocess": "^4.7.4",
     "svelte-waypoint": "^0.1.4",
+    "svelte-webext-stores": "^0.0.10",
     "tailwindcss": "^2.2.7",
     "ts-loader": "^9.2.4",
     "typescript": "^4.3.5",

--- a/src/components/HyperchatButton.svelte
+++ b/src/components/HyperchatButton.svelte
@@ -1,10 +1,11 @@
 <script lang='ts'>
   import { isLiveTL } from '../ts/chat-constants';
+  import { hcEnabled } from '../ts/storage';
 
-  const disabled = localStorage.getItem('HC:ENABLED') === 'false';
+  $: disabled = !$hcEnabled;
 
   const onClick = () => {
-    localStorage.setItem('HC:ENABLED', disabled ? 'true' : 'false');
+    $hcEnabled = !$hcEnabled;
     location.reload();
   };
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -5,6 +5,7 @@
   "description": "YouTube chat, but it's fast and sleek!",
   "version": "42.0.69",
   "permissions": [
+    "storage"
   ],
   "icons": {
     "48": "assets/logo-48.png",

--- a/src/ts/storage.ts
+++ b/src/ts/storage.ts
@@ -1,0 +1,5 @@
+import { webExtStores } from 'svelte-webext-stores';
+
+export const stores = webExtStores();
+
+export const hcEnabled = stores.addSyncStore('hc-enabled', true);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,10 +11,7 @@
       "DOM"
     ],
     "target": "ES6",
-    "resolveJsonModule": true,
-    "typeRoots": [
-      "./node_modules/@types"
-    ]
+    "resolveJsonModule": true
   },
   "include": [
     "src/**/*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4727,6 +4727,11 @@ svelte-waypoint@^0.1.4:
   resolved "https://registry.yarnpkg.com/svelte-waypoint/-/svelte-waypoint-0.1.4.tgz#ab467bed08c5f38716709872cf53d3f9da17831b"
   integrity sha512-UEqoXZjJeKj2sWlAIsBOFjxjMn+KP8aFCc/zjdmZi1cCOE59z6T2C+I6ZaAf8EmNQqNzfZVB/Lci4Ci9spzXAw==
 
+svelte-webext-stores@^0.0.10:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/svelte-webext-stores/-/svelte-webext-stores-0.0.10.tgz#2bc14b93541bb91904348e51e0bf37e87cb0c4dd"
+  integrity sha512-jBbFMcZHxVQ9gEQpaOa0QBZei2rZjNhHvYNtiiphdMVQ/67y6Kl6R++6HUFKMLjeFDkTSWQa5kQAXQds2lqvlA==
+
 svelte@^3.31.2, svelte@^3.41.0:
   version "3.41.0"
   resolved "https://registry.yarnpkg.com/svelte/-/svelte-3.41.0.tgz#2009fd6681453ffb8b5aaa57f4a89a8be3dedd78"


### PR DESCRIPTION
Start using extension storage instead of `localStorage` via [svelte-webext-stores](https://github.com/ChrRubin/svelte-webext-stores) by yours truly. The lib is fully TypeScript-ed and migrating to MV3 whenever that happens should be as simple as adding a parameter.

For now this is only used for the enable HC toggle, but it'll open up the opportunity to implement other settings related feature requests.

Fixes #31.