### PR TITLE
Fix paid message text color

### DIFF
--- a/src/components/TranslatedMessage.svelte
+++ b/src/components/TranslatedMessage.svelte
@@ -27,13 +27,10 @@
   }
 
   $: translatedColor = forceDark ? 'text-translated-dark' : 'dark:text-translated-dark text-translated-light';
-  $: stockTextColor = forceDark ? 'text-white' : 'dark:text-white text-black';
 </script>
 
 <span 
-  class={
-    showTL ? translatedColor : stockTextColor
-  }
+  class={showTL ? translatedColor : ''}
   class:cursor-pointer={translatedMessage}
   class:entrance-animation={translatedMessage}
   on:click={() => {


### PR DESCRIPTION
Paid message text colors from YT JSON were getting overridden by the text color classes here.

The correct text colors should already be set on the ancestors, so there's no need to set the "stock" text colors again anyway.