### PR TITLE
improved tl colors for superchats

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "eslint-plugin-svelte3": "^3.2.0",
     "express": "4.17.1",
     "iframe-translator": "^0.2.2",
+    "is-dark-color": "^1.2.0",
     "postcss": "^8.3.6",
     "postcss-extend": "^1.0.5",
     "postcss-import": "^14.0.2",

--- a/src/components/Message.svelte
+++ b/src/components/Message.svelte
@@ -7,6 +7,7 @@
     showTimestamps,
     showUserBadges
   } from '../ts/storage';
+  import { Theme } from '../ts/chat-constants';
 
   export let message: Ytc.ParsedMessage;
   export let deleted: Chat.MessageDeletedObj | null = null;
@@ -52,6 +53,8 @@
 
   $: showUserMargin = $showProfileIcons || $showUsernames || $showTimestamps ||
     ($showUserBadges && (moderator || verified || member));
+  
+  export let forceTLColor: Theme = Theme.YOUTUBE;
 </script>
 
 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
@@ -100,6 +103,6 @@
       </span>
       <span class="mr-1.5" class:hidden={!showUserMargin} />
     {/if}
-    <MessageRun runs={message.message} {forceDark} deleted={deleted != null} />
+    <MessageRun runs={message.message} {forceDark} deleted={deleted != null} {forceTLColor} />
   </div>
 </div>

--- a/src/components/MessageRuns.svelte
+++ b/src/components/MessageRuns.svelte
@@ -1,9 +1,12 @@
 <script lang="ts">
+  import type { Theme } from '../ts/chat-constants';
+
   import TranslatedMessage from './TranslatedMessage.svelte';
 
   export let runs: Ytc.ParsedRun[];
   export let forceDark = false;
   export let deleted = false;
+  export let forceTLColor: Theme;
 
   let deletedClass = '';
 
@@ -26,7 +29,7 @@
       {#if deleted}
         <span>{run.text}</span>
       {:else}
-        <TranslatedMessage text={run.text} {forceDark} />
+        <TranslatedMessage text={run.text} {forceTLColor} />
       {/if}
     {:else if run.type === 'link'}
       <a

--- a/src/components/PaidMessage.svelte
+++ b/src/components/PaidMessage.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
   import Message from './Message.svelte';
+  import isDarkColor from 'is-dark-color';
+  import { Theme } from '../ts/chat-constants';
 
   export let message: Ytc.ParsedMessage;
 
@@ -41,7 +43,9 @@
     </div>
     {#if message.message.length > 0}
       <div class="p-2">
-        <Message message={message} hideName />
+        <Message message={message} hideName forceTLColor={
+          isDarkColor(`#${message.superChat?.headerTextColor}`) ? Theme.LIGHT : Theme.DARK
+        } />
       </div>
     {/if}
   </div>

--- a/src/components/TranslatedMessage.svelte
+++ b/src/components/TranslatedMessage.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
   import { refreshScroll, translatorClient, translateTargetLanguage } from '../ts/storage';
   import Icon from './common/Icon.svelte';
+  import { Theme } from '../ts/chat-constants';
 
-  export let forceDark = false;
+  export let forceTLColor: Theme = Theme.YOUTUBE;
 
   export let text: string;
   let translatedMessage = '';
@@ -26,7 +27,11 @@
     translatedLanguage = '';
   }
 
-  $: translatedColor = forceDark ? 'text-translated-dark' : 'dark:text-translated-dark text-translated-light';
+  $: console.log(forceTLColor);
+
+  $: translatedColor = forceTLColor === Theme.DARK
+    ? 'text-translated-dark'
+    : `text-translated-light ${forceTLColor === Theme.YOUTUBE ? 'dark:text-translated-dark' : ''}`;
 </script>
 
 <span 

--- a/src/ts/typings/imports.d.ts
+++ b/src/ts/typings/imports.d.ts
@@ -1,0 +1,3 @@
+declare module 'is-dark-color' {
+  export default function isDarkColor(color: `#${string}`): boolean;
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -33,8 +33,8 @@ const smelteConfig = {
           dark: '#898888'
         },
         translated: {
-          light: '#0050da',
-          dark: '#b9d9ff'
+          light: '#004abd',
+          dark: '#d4ebff'
         }
       }
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3496,6 +3496,11 @@ is-core-module@^2.2.0, is-core-module@^2.4.0:
   dependencies:
     has "^1.0.3"
 
+is-dark-color@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/is-dark-color/-/is-dark-color-1.2.0.tgz#60dea9b56cfd6e3a286fcf59e3ab78fd60a2c77d"
+  integrity sha512-07rMiXL60NRntHOMLp5A/2hVw+JGyQco7YS8mkg4y3FP0mTl68fm7/xVLuVR/8minoEQJKVqQ+xSgBlclaN5qA==
+
 is-date-object@^1.0.1:
   version "1.0.4"
   resolved "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.4.tgz"


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/38841491/155430351-751e0d23-4812-4a1d-854b-43acdaa6ce4b.png)
![image](https://user-images.githubusercontent.com/38841491/155430364-5491fa51-82b1-44b5-99b4-974d35289447.png)
![image](https://user-images.githubusercontent.com/38841491/155430389-0f9cbaa2-8273-44b3-abb0-8319aded70cf.png)
![image](https://user-images.githubusercontent.com/38841491/155430642-a198f51e-2122-413b-9844-ad70c8b5921d.png)
![image](https://user-images.githubusercontent.com/38841491/155430653-2e896a0b-333a-4086-8c2f-41e20a054d82.png)

> note: must install `is-dark-color` when merging to ltl