### PR TITLE
reduced chat delay

### DIFF
--- a/src/ts/chat-parser.ts
+++ b/src/ts/chat-parser.ts
@@ -211,8 +211,9 @@ const sortAction = (action: Ytc.ParsedAction, messageArray: Ytc.ParsedMessage[],
 
 const cheatTimestamps = (arr: Ytc.ParsedMessage[]): void => {
   const earliest = arr[0].showtime;
+  const delta = Date.now() - earliest;
   arr.forEach(item => {
-    item.showtime += Date.now() - earliest;
+    item.showtime += delta;
   });
 };
 


### PR DESCRIPTION
I figured out a trick to make the delay negligible.

When a chunk is received and is completely sorted, we assume that the first message in the chunk is meant to be displayed immediately. All messages that follow are timed relative to the first message. I think this is what ytc does internally, since the timing is very very close to default ytc. So much so that screenshots in chilledcow chat show an identical list of messages

left hc, right ytc.

![image](https://user-images.githubusercontent.com/38841491/159346715-7aedceef-ab78-44e4-bd1f-10a785468023.png)
