### PR TITLE
Fix LTL compatibility issue (again)

### DIFF
--- a/src/scripts/chat-injector.ts
+++ b/src/scripts/chat-injector.ts
@@ -1,5 +1,5 @@
 import HcButton from '../components/HyperchatButton.svelte';
-import { getFrameInfoAsync, isValidFrameInfo, frameIsReplay } from '../ts/chat-utils';
+import { getFrameInfoAsync, isValidFrameInfo, frameIsReplay, checkInjected } from '../ts/chat-utils';
 import { isLiveTL, isAndroid } from '../ts/chat-constants';
 import { hcEnabled, autoLiveChat } from '../ts/storage';
 
@@ -12,10 +12,7 @@ const hcWarning = 'An existing HyperChat button has been detected. This ' +
   'problems such as chat messages not loading.';
 
 const chatLoaded = async (): Promise<void> => {
-  if (document.querySelector('.toggleButton')) {
-    console.error(hcWarning);
-    return;
-  }
+  if (!isLiveTL && checkInjected(hcWarning)) return;
 
   document.body.style.minWidth = document.body.style.minHeight = '0px';
   const hyperChatEnabled = await hcEnabled.get();
@@ -96,8 +93,6 @@ const chatLoaded = async (): Promise<void> => {
   }
 };
 
-if (document.readyState === 'loading') {
-  document.addEventListener('DOMContentLoaded', () => async () => await chatLoaded());
-} else {
-  chatLoaded().catch(e => console.error(e));
-}
+setTimeout(() => {
+  chatLoaded().catch(console.error);
+}, isLiveTL ? 0 : 500);

--- a/src/scripts/chat-interceptor.ts
+++ b/src/scripts/chat-interceptor.ts
@@ -1,5 +1,6 @@
 import { fixLeaks } from '../ts/ytc-fix-memleaks';
-import { frameIsReplay as isReplay } from '../ts/chat-utils';
+import { frameIsReplay as isReplay, checkInjected } from '../ts/chat-utils';
+import { isLiveTL } from '../ts/chat-constants';
 
 function injectedFunction(): void {
   for (const eventName of ['visibilitychange', 'webkitvisibilitychange', 'blur']) {
@@ -27,10 +28,8 @@ function injectedFunction(): void {
 }
 
 const chatLoaded = async (): Promise<void> => {
-  if (document.querySelector('.toggleButton')) {
-    console.error('HC button detected, not injecting interceptor.');
-    return;
-  }
+  const warning = 'HC button detected, not injecting interceptor.';
+  if (!isLiveTL && checkInjected(warning)) return;
 
   // Inject interceptor script
   const script = document.createElement('script');
@@ -111,8 +110,6 @@ const chatLoaded = async (): Promise<void> => {
   document.body.appendChild(fixLeakScript);
 };
 
-if (document.readyState === 'loading') {
-  document.addEventListener('DOMContentLoaded', () => async () => await chatLoaded());
-} else {
-  chatLoaded().catch(e => console.error(e));
-}
+setTimeout(() => {
+  chatLoaded().catch(console.error);
+}, isLiveTL ? 0 : 500);

--- a/src/ts/chat-utils.ts
+++ b/src/ts/chat-utils.ts
@@ -49,3 +49,11 @@ export const isChatMessage = (a: Chat.MessageAction): boolean =>
 
 export const isAllEmoji = (a: Chat.MessageAction): boolean =>
   a.message.message.every(m => m.type === 'emoji' || (m.type === 'text' && m.text.trim() === ''));
+
+export const checkInjected = (error: string): boolean => {
+  if (document.querySelector('#hc-buttons')) {
+    console.error(error);
+    return true;
+  }
+  return false;
+};


### PR DESCRIPTION
The duplicate injection check is now only done by standalone HC, so only standalone HC will stop injecting its scripts when an existing injection is detected, and not LTL. A 500ms delay is added for standalone HC to help with the race condition around extension loading.

I've also removed the `readyState === 'loading'` stuff since I never got it to work properly.

Fixes LiveTL/LiveTL#394.