### PR TITLE
Load scripts immediately for LTL

### DIFF
--- a/src/components/Hyperchat.svelte
+++ b/src/components/Hyperchat.svelte
@@ -167,6 +167,8 @@
       case 'themeUpdate':
         ytDark = response.dark;
         break;
+      case 'registerClientResponse':
+        break;
       default:
         console.error('Unknown payload type', { port, response });
         break;

--- a/src/scripts/chat-background.ts
+++ b/src/scripts/chat-background.ts
@@ -156,12 +156,28 @@ const registerClient = (
     frameInfo,
     { interceptors, port, frameInfo }
   );
-  if (!interceptor) return;
+  if (!interceptor) {
+    port.postMessage(
+      {
+        type: 'registerClientResponse',
+        success: false,
+        failReason: 'Interceptor not found'
+      }
+    );
+    return;
+  }
 
   if (interceptor.clients.some((client) => client.name === port.name)) {
     console.debug(
       'Client already registered. Not registering',
       { interceptors, port, frameInfo }
+    );
+    port.postMessage(
+      {
+        type: 'registerClientResponse',
+        success: false,
+        failReason: 'Client already registered'
+      }
     );
     return;
   }
@@ -187,6 +203,12 @@ const registerClient = (
   // Add client to array
   interceptor.clients.push(port);
   console.debug('Register client successful', { port, interceptor });
+  port.postMessage(
+    {
+      type: 'registerClientResponse',
+      success: true
+    }
+  );
 
   if (getInitialData && isYtcInterceptor(interceptor)) {
     const payload = {

--- a/src/scripts/chat-injector.ts
+++ b/src/scripts/chat-injector.ts
@@ -93,6 +93,10 @@ const chatLoaded = async (): Promise<void> => {
   }
 };
 
-setTimeout(() => {
+if (isLiveTL) {
   chatLoaded().catch(console.error);
-}, isLiveTL ? 0 : 500);
+} else {
+  setTimeout(() => {
+    chatLoaded().catch(console.error);
+  }, 500);
+}

--- a/src/scripts/chat-interceptor.ts
+++ b/src/scripts/chat-interceptor.ts
@@ -110,6 +110,10 @@ const chatLoaded = async (): Promise<void> => {
   document.body.appendChild(fixLeakScript);
 };
 
-setTimeout(() => {
+if (isLiveTL) {
   chatLoaded().catch(console.error);
-}, isLiveTL ? 0 : 500);
+} else {
+  setTimeout(() => {
+    chatLoaded().catch(console.error);
+  }, 500);
+}

--- a/src/ts/typings/chat.d.ts
+++ b/src/ts/typings/chat.d.ts
@@ -61,7 +61,13 @@ declare namespace Chat {
     message: LtlMessage;
   }
 
-  type BackgroundResponse = Actions | InitialData | ThemeUpdate | LtlMessageResponse;
+  interface registerClientResponse {
+    type: 'registerClientResponse';
+    success: boolean;
+    failReason?: string;
+  }
+
+  type BackgroundResponse = Actions | InitialData | ThemeUpdate | LtlMessageResponse | registerClientResponse;
 
   type InterceptorSource = 'ytc' | 'ltlMessage';
 


### PR DESCRIPTION
So apparently `setTimeout` with 0 delay doesn't always execute immediately, which was causing LTL to fail randomly because the YTC interceptor haven't loaded.

The `chat-interceptor` and `chat-injector` scripts will now run without `setTimeout` on LTL, which was the previous behaviour. While this was enough to fix the issue, I've added response messages so LTL can handle failed registration, just in case.