### PR TITLE
add duplicateKeyBlocker to fix freezing issues

### DIFF
--- a/src/components/Hyperchat.svelte
+++ b/src/components/Hyperchat.svelte
@@ -46,6 +46,7 @@
   const CHAT_HISTORY_SIZE = 150;
   const TRUNCATE_SIZE = 20;
   let messageActions: (Chat.MessageAction | Welcome)[] = [];
+  const messageKeys = new Set<string>();
   let pinned: Ytc.ParsedPinned | null;
   let div: HTMLElement;
   let isAtBottom = true;
@@ -66,7 +67,13 @@
     isAllEmoji(a)
   );
 
-  const messageBlockers = [memberOnlyBlocker, emojiSpamBlocker];
+  const duplicateKeyBlocker: MessageBlocker = (a) => {
+    const result = messageKeys.has(a.message.messageId);
+    messageKeys.add(a.message.messageId);
+    return result;
+  };
+
+  const messageBlockers = [memberOnlyBlocker, emojiSpamBlocker, duplicateKeyBlocker];
 
   const shouldShowMessage = (m: Chat.MessageAction): boolean => (
     !messageBlockers.some(blocker => blocker(m))
@@ -87,7 +94,10 @@
 
   const checkTruncateMessages = (): void => {
     const diff = messageActions.length - CHAT_HISTORY_SIZE;
-    if (diff > TRUNCATE_SIZE) messageActions.splice(0, diff);
+    if (diff > TRUNCATE_SIZE) {
+      const removed = messageActions.splice(0, diff);
+      removed.forEach(m => messageKeys.delete(m.message.messageId));
+    }
     messageActions = messageActions;
   };
 

--- a/src/components/Hyperchat.svelte
+++ b/src/components/Hyperchat.svelte
@@ -176,6 +176,7 @@
         $currentProgress = action.playerProgress;
         break;
       case 'forceUpdate':
+        messageKeys.clear();
         messageActions = [...action.messages].filter(shouldShowMessage);
         if (action.showWelcome) {
           messageActions = [...messageActions, welcome];

--- a/src/components/MessageRuns.svelte
+++ b/src/components/MessageRuns.svelte
@@ -7,7 +7,7 @@
   } from '../ts/storage';
   import { YoutubeEmojiRenderMode } from '../ts/chat-constants';
 
-  export let runs: Ytc.ParsedRun[] | null;
+  export let runs: Ytc.ParsedRun[];
   export let forceDark = false;
   export let deleted = false;
   export let forceTLColor: Theme = Theme.YOUTUBE;
@@ -23,53 +23,39 @@
   }
 </script>
 
-<!--
-  The `runs` prop is supposed to always be an array,
-  but somewhere, somehow, sometimes, YouTube forgets
-  to provide us an array.
-  
-  This is sorta cheap, but the easiest solution is
-  to safeguard a null prop value with a simple check.
-
-  If anyone wants to find a more elegant solution,
-  see this bug report:
-  https://discord.com/channels/780938154437640232/788107573755904070/983867679968477215
--->
-{#if runs?.length}
-  <span
-    class="cursor-auto align-middle {deletedClass} {$$props.class ?? ''}"
-    style="word-break: break-word"
-  >
-    {#each runs as run}
-      {#if run.type === 'text'}
-        {#if deleted}
-          <span>{run.text}</span>
-        {:else}
-          <TranslatedMessage text={run.text} {forceTLColor} />
-        {/if}
-      {:else if run.type === 'link'}
-        <a
-          class="inline underline align-middle"
-          href={run.url}
-          target="_blank"
-        >
-          {run.text}
-        </a>
-      {:else if run.type === 'emoji' && $emojiRenderMode !== YoutubeEmojiRenderMode.HIDE_ALL}
-        {#if run.standardEmoji && $useSystemEmojis}
-          <span
-            class="cursor-auto align-middle text-base"
-          >
-            {run.alt}
-          </span>
-        {:else if run.src}
-          <img
-            class="h-5 w-5 inline mx-0.5 align-middle"
-            src={run.src}
-            alt={run.alt}
-          />
-        {/if}
+<span
+  class="cursor-auto align-middle {deletedClass} {$$props.class ?? ''}"
+  style="word-break: break-word"
+>
+  {#each runs as run}
+    {#if run.type === 'text'}
+      {#if deleted}
+        <span>{run.text}</span>
+      {:else}
+        <TranslatedMessage text={run.text} {forceTLColor} />
       {/if}
-    {/each}
-  </span>
-{/if}
+    {:else if run.type === 'link'}
+      <a
+        class="inline underline align-middle"
+        href={run.url}
+        target="_blank"
+      >
+        {run.text}
+      </a>
+    {:else if run.type === 'emoji' && $emojiRenderMode !== YoutubeEmojiRenderMode.HIDE_ALL}
+      {#if run.standardEmoji && $useSystemEmojis}
+        <span
+          class="cursor-auto align-middle text-base"
+        >
+          {run.alt}
+        </span>
+      {:else if run.src}
+        <img
+          class="h-5 w-5 inline mx-0.5 align-middle"
+          src={run.src}
+          alt={run.alt}
+        />
+      {/if}
+    {/if}
+  {/each}
+</span>

--- a/src/components/MessageRuns.svelte
+++ b/src/components/MessageRuns.svelte
@@ -7,7 +7,7 @@
   } from '../ts/storage';
   import { YoutubeEmojiRenderMode } from '../ts/chat-constants';
 
-  export let runs: Ytc.ParsedRun[];
+  export let runs: Ytc.ParsedRun[] | null;
   export let forceDark = false;
   export let deleted = false;
   export let forceTLColor: Theme = Theme.YOUTUBE;
@@ -23,39 +23,53 @@
   }
 </script>
 
-<span
-  class="cursor-auto align-middle {deletedClass} {$$props.class ?? ''}"
-  style="word-break: break-word"
->
-  {#each runs as run}
-    {#if run.type === 'text'}
-      {#if deleted}
-        <span>{run.text}</span>
-      {:else}
-        <TranslatedMessage text={run.text} {forceTLColor} />
-      {/if}
-    {:else if run.type === 'link'}
-      <a
-        class="inline underline align-middle"
-        href={run.url}
-        target="_blank"
-      >
-        {run.text}
-      </a>
-    {:else if run.type === 'emoji' && $emojiRenderMode !== YoutubeEmojiRenderMode.HIDE_ALL}
-      {#if run.standardEmoji && $useSystemEmojis}
-        <span
-          class="cursor-auto align-middle text-base"
+<!--
+  The `runs` prop is supposed to always be an array,
+  but somewhere, somehow, sometimes, YouTube forgets
+  to provide us an array.
+  
+  This is sorta cheap, but the easiest solution is
+  to safeguard a null prop value with a simple check.
+
+  If anyone wants to find a more elegant solution,
+  see this bug report:
+  https://discord.com/channels/780938154437640232/788107573755904070/983867679968477215
+-->
+{#if runs?.length}
+  <span
+    class="cursor-auto align-middle {deletedClass} {$$props.class ?? ''}"
+    style="word-break: break-word"
+  >
+    {#each runs as run}
+      {#if run.type === 'text'}
+        {#if deleted}
+          <span>{run.text}</span>
+        {:else}
+          <TranslatedMessage text={run.text} {forceTLColor} />
+        {/if}
+      {:else if run.type === 'link'}
+        <a
+          class="inline underline align-middle"
+          href={run.url}
+          target="_blank"
         >
-          {run.alt}
-        </span>
-      {:else if run.src}
-        <img
-          class="h-5 w-5 inline mx-0.5 align-middle"
-          src={run.src}
-          alt={run.alt}
-        />
+          {run.text}
+        </a>
+      {:else if run.type === 'emoji' && $emojiRenderMode !== YoutubeEmojiRenderMode.HIDE_ALL}
+        {#if run.standardEmoji && $useSystemEmojis}
+          <span
+            class="cursor-auto align-middle text-base"
+          >
+            {run.alt}
+          </span>
+        {:else if run.src}
+          <img
+            class="h-5 w-5 inline mx-0.5 align-middle"
+            src={run.src}
+            alt={run.alt}
+          />
+        {/if}
       {/if}
-    {/if}
-  {/each}
-</span>
+    {/each}
+  </span>
+{/if}


### PR DESCRIPTION
this pr is fairly urgent, @r2dev2 @ChrRubin please review and approve as soon as possible

![image](https://user-images.githubusercontent.com/38841491/174562075-e1a5326d-cac2-4031-b4a8-9f8d157b2d07.png)

this happens when a duplicate message entry is added to the message array. svelte doesn't know what to do with duplicate keys, freezing the entire app.

the solution i implemented is to use a set of messageIds, tracking all rendered keys and checking against the set before adding to the message array. performance should be fine because js Set is sublinear time (`O(1) <= x < O(n)`), and even if close to `O(n)`, our `n` is like 250