### PR TITLE
show chip if hc updates while it's disabled

### DIFF
--- a/src/components/Hyperchat.svelte
+++ b/src/components/Hyperchat.svelte
@@ -37,8 +37,10 @@
     alertDialog,
     stickySuperchats,
     currentProgress,
-    enableStickySuperchatBar
+    enableStickySuperchatBar,
+    lastOpenedVersion
   } from '../ts/storage';
+  import { version } from '../manifest.json';
 
   const welcome = { welcome: true, message: { messageId: 'welcome' } };
   type Welcome = typeof welcome;
@@ -241,6 +243,7 @@
 
   // Doesn't work well with onMount, so onLoad will have to do
   const onLoad = () => {
+    $lastOpenedVersion = version;
     document.body.classList.add('overflow-hidden');
 
     if (paramsTabId == null || paramsFrameId == null || paramsTabId.length < 1 || paramsFrameId.length < 1) {

--- a/src/components/HyperchatButton.svelte
+++ b/src/components/HyperchatButton.svelte
@@ -2,7 +2,7 @@
   import { isLiveTL } from '../ts/chat-constants';
   import { hcEnabled, lastOpenedVersion } from '../ts/storage';
   import { createPopup } from '../ts/chat-utils';
-  import { mdiCogOutline } from '@mdi/js';
+  import { mdiChevronRight, mdiClose, mdiCogOutline } from '@mdi/js';
   import { version } from '../manifest.json';
 
   $: disabled = !$hcEnabled;
@@ -33,17 +33,16 @@
     <div class="update-notification">
       Updated!
       <svg height="24" width="24" viewBox="0 0 24 24" class="chevron">
-        <path d="M0 0h24v24H0z" fill="none"/><path d="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"/>
+        <path d={mdiChevronRight} fill="black"/>
       </svg>
-      <a href="/" on:click={(e) => {
-        e.preventDefault();
+      <div style="cursor: pointer;" on:click={() => {
         updated = false;
         $lastOpenedVersion = version;
       }}>
         <svg height="20" width="24" viewBox="0 0 24 24" class="close">
-          <path d="M0 0h24v24H0z" fill="none"/><path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"/>
+          <path d={mdiClose} fill="black"/>
         </svg>
-      </a>
+      </div>
     </div>
   {/if}
   <div class="tooltip-bottom" data-tooltip="{disabled ? 'Enable' : 'Disable'} HyperChat">
@@ -327,7 +326,6 @@
     font-size: 1.5rem;
     justify-content: center;
     align-items: center;
-    cursor: default;
   }
   .close {
     display: none;

--- a/src/components/HyperchatButton.svelte
+++ b/src/components/HyperchatButton.svelte
@@ -1,8 +1,9 @@
 <script lang='ts'>
   import { isLiveTL } from '../ts/chat-constants';
-  import { hcEnabled } from '../ts/storage';
+  import { hcEnabled, lastOpenedVersion } from '../ts/storage';
   import { createPopup } from '../ts/chat-utils';
   import { mdiCogOutline } from '@mdi/js';
+  import { version } from '../manifest.json';
 
   $: disabled = !$hcEnabled;
 
@@ -20,7 +21,11 @@
   const logo = chrome.runtime.getURL((isLiveTL ? 'hyperchat' : 'assets') + '/logo-48.png');
   const simplified = chrome.runtime.getURL((isLiveTL ? 'hyperchat' : 'assets') + '/simplified.png');
 
-  let updated = !disabled;
+  let updated = false;
+
+  lastOpenedVersion.ready().then(() => {
+    updated = !$hcEnabled && $lastOpenedVersion !== version;
+  });
 </script>
 
 <div id="hc-buttons">
@@ -33,6 +38,7 @@
       <a href="/" on:click={(e) => {
         e.preventDefault();
         updated = false;
+        $lastOpenedVersion = version;
       }}>
         <svg height="20" width="24" viewBox="0 0 24 24" class="close">
           <path d="M0 0h24v24H0z" fill="none"/><path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"/>
@@ -62,6 +68,7 @@
   #hc-buttons {
     float: right;
     display: flex;
+    user-select: none;
   }
 
   .toggleButton {
@@ -320,6 +327,7 @@
     font-size: 1.5rem;
     justify-content: center;
     align-items: center;
+    cursor: default;
   }
   .close {
     display: none;

--- a/src/components/HyperchatButton.svelte
+++ b/src/components/HyperchatButton.svelte
@@ -19,9 +19,27 @@
 
   const logo = chrome.runtime.getURL((isLiveTL ? 'hyperchat' : 'assets') + '/logo-48.png');
   const simplified = chrome.runtime.getURL((isLiveTL ? 'hyperchat' : 'assets') + '/simplified.png');
+
+  let updated = !disabled;
 </script>
 
 <div id="hc-buttons">
+  {#if updated}
+    <div class="update-notification">
+      Updated!
+      <svg height="24" width="24" viewBox="0 0 24 24" class="chevron">
+        <path d="M0 0h24v24H0z" fill="none"/><path d="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"/>
+      </svg>
+      <a href="/" on:click={(e) => {
+        e.preventDefault();
+        updated = false;
+      }}>
+        <svg height="20" width="24" viewBox="0 0 24 24" class="close">
+          <path d="M0 0h24v24H0z" fill="none"/><path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"/>
+        </svg>
+      </a>
+    </div>
+  {/if}
   <div class="tooltip-bottom" data-tooltip="{disabled ? 'Enable' : 'Disable'} HyperChat">
     <div class="toggleButton" class:disabled on:click={toggleHc} >
       <img src={logo} alt="hc-logo"/>
@@ -291,5 +309,25 @@
     -webkit-transform: translateY(12px);
     -moz-transform:    translateY(12px);
     transform:         translateY(12px); 
+  }
+
+  .update-notification {
+    background-color: rgb(224, 172, 0);
+    color: black;
+    display: flex;
+    border-radius: 1000px;
+    padding-left: 10px;
+    font-size: 1.5rem;
+    justify-content: center;
+    align-items: center;
+  }
+  .close {
+    display: none;
+  }
+  .update-notification:hover .chevron {
+    display: none;
+  }
+  .update-notification:hover .close {
+    display: block;
   }
 </style>

--- a/src/ts/storage.ts
+++ b/src/ts/storage.ts
@@ -7,7 +7,7 @@ import { ChatReportUserOptions, Theme, YoutubeEmojiRenderMode } from './chat-con
 
 export const stores = webExtStores();
 
-export const hcEnabled = stores.addSyncStore('hc.enabled', true);
+export const hcEnabled = stores.addSyncStore('hc.enabled', false);
 export const translateTargetLanguage = stores.addSyncStore('hc.translateTargetLanguage', '' as '' | AvailableLanguageCodes);
 export const translatorClient = readable(null as (null | IframeTranslatorClient), (set) => {
   let client: IframeTranslatorClient | null = null;

--- a/src/ts/storage.ts
+++ b/src/ts/storage.ts
@@ -75,3 +75,4 @@ export const isDark = derived(theme, ($theme) => {
 });
 export const currentProgress = writable(null as null | number);
 export const enableStickySuperchatBar = stores.addSyncStore('hc.enableStickySuperchatBar', true);
+export const lastOpenedVersion = stores.addSyncStore('hc.lastOpenedVersion', '');

--- a/src/ts/storage.ts
+++ b/src/ts/storage.ts
@@ -7,7 +7,7 @@ import { ChatReportUserOptions, Theme, YoutubeEmojiRenderMode } from './chat-con
 
 export const stores = webExtStores();
 
-export const hcEnabled = stores.addSyncStore('hc.enabled', false);
+export const hcEnabled = stores.addSyncStore('hc.enabled', true);
 export const translateTargetLanguage = stores.addSyncStore('hc.translateTargetLanguage', '' as '' | AvailableLanguageCodes);
 export const translatorClient = readable(null as (null | IframeTranslatorClient), (set) => {
   let client: IframeTranslatorClient | null = null;


### PR DESCRIPTION
taishi didn't know that hyperchat had user reporting and blocking because he had hyperchat turned off and never saw the changelogs (outside of the minimized livetl changelogs). i think there are probably quite a few people who have hyperchat disabled most of the time because of something they dont like, not realizing that the feature has been implemented recently. this chip would help alert those users that there's new stuff they don't know about

![image](https://user-images.githubusercontent.com/38841491/175760742-b89c052a-9eca-4a29-aa2d-5e4008059247.png)

when hovered, the chip chevron turns into an `x`.

![image](https://user-images.githubusercontent.com/38841491/175761648-b91c0064-1efc-49cb-80dc-6d3addf85be5.png)
![image](https://user-images.githubusercontent.com/38841491/175761649-ad0c6b2b-3f29-4bdf-9976-8c0662ad02b8.png)
