### PR TITLE
Forward player timestamp to twitch clients

### DIFF
--- a/src/scripts/chat-background.ts
+++ b/src/scripts/chat-background.ts
@@ -316,9 +316,17 @@ const setInitialData = (port: Chat.Port, message: Chat.JsonMsg): void => {
  */
 const updatePlayerProgress = (port: Chat.Port, playerProgress: number, isFromYt?: boolean): void => {
   const interceptor = findInterceptorFromPort(port, { playerProgress });
-  if (!interceptor || !isYtcInterceptor(interceptor)) return;
+  if (!interceptor) return;
 
-  interceptor.queue.updatePlayerProgress(playerProgress, isFromYt);
+  // yt needs logic for clearing chat messages and forcing updates
+  // yt's updatePlayerProgress will send the playerProgress message in the method
+  if (isYtcInterceptor(interceptor)) {
+    interceptor.queue.updatePlayerProgress(playerProgress, isFromYt);
+  }
+  // send to all twitch clients
+  else {
+    interceptor.clients.forEach(port => port.postMessage({ type: 'playerProgress', playerProgress }));
+  }
 };
 
 /**

--- a/src/scripts/chat-background.ts
+++ b/src/scripts/chat-background.ts
@@ -322,9 +322,7 @@ const updatePlayerProgress = (port: Chat.Port, playerProgress: number, isFromYt?
   // yt's updatePlayerProgress will send the playerProgress message in the method
   if (isYtcInterceptor(interceptor)) {
     interceptor.queue.updatePlayerProgress(playerProgress, isFromYt);
-  }
-  // send to all twitch clients
-  else {
+  } else { // send to all twitch clients
     interceptor.clients.forEach(port => port.postMessage({ type: 'playerProgress', playerProgress }));
   }
 };


### PR DESCRIPTION
Currently, playerProgress event is only forwarded to YouTube clients (HyperChat and Youtube LiveTL). It needs to be forwarded to twitch clients (Twitch LiveTL) for https://github.com/LiveTL/LiveTL/issues/428.