### PR TITLE
Firefox MV3

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ yarn start # alias to yarn dev:chrome for backwards compat
 yarn start:none # alias to yarn dev:chrome for backwards compat
 yarn start:firefox # devserver + open extension in firefox
 yarn start:chrome # devserver + open extension in chrome
-yarn build # production mode (firefox)
+yarn build # production mode (chrome)
 yarn build:chrome # production mode (chrome)
+yarn build:firefox # production mode (firefox)
 VERSION=x.x.x yarn build
 ```

--- a/README.md
+++ b/README.md
@@ -29,7 +29,13 @@ yarn # install dependencies
 Build or serve the extension:
 
 ```bash
-yarn start # watch mode
-yarn build # production mode
+yarn dev:firefox # devserver for firefox extension
+yarn dev:chrome # devserver for chrome extension
+yarn start # alias to yarn dev:chrome for backwards compat
+yarn start:none # alias to yarn dev:chrome for backwards compat
+yarn start:firefox # devserver + open extension in firefox
+yarn start:chrome # devserver + open extension in chrome
+yarn build # production mode (firefox)
+yarn build:chrome # production mode (chrome)
 VERSION=x.x.x yarn build
 ```

--- a/package.json
+++ b/package.json
@@ -3,8 +3,9 @@
   "version": "69.42.0",
   "private": true,
   "scripts": {
-    "build": "vite build",
+    "build": "yarn build:chrome",
     "build:chrome": "cross-env BROWSER=chrome vite build",
+    "build:firefox": "cross-env BROWSER=firefox vite build",
     "package": "node utils/package.js",
     "dev:chrome": "cross-env MINIFY=false BROWSER=chrome vite build --watch",
     "dev:firefox": "cross-env MINIFY=false BROWSER=firefox vite build --watch",

--- a/package.json
+++ b/package.json
@@ -4,10 +4,14 @@
   "private": true,
   "scripts": {
     "build": "vite build",
+    "build:chrome": "cross-env BROWSER=chrome vite build",
     "package": "node utils/package.js",
-    "start": "cross-env MINIFY=false BROWSER=none vite build --watch",
-    "start:chrome": "cross-env MINIFY=false BROWSER=chrome vite build --watch",
-    "start:firefox": "cross-env MINIFY=false BROWSER=firefox vite build --watch",
+    "dev:chrome": "cross-env MINIFY=false BROWSER=chrome vite build --watch",
+    "dev:firefox": "cross-env MINIFY=false BROWSER=firefox vite build --watch",
+    "start": "yarn dev:chrome",
+    "start:none": "yarn dev:chrome",
+    "start:chrome": "cross-env HC_AUTOLAUNCH=menace yarn dev:chrome",
+    "start:firefox": "cross-env HC_AUTOLAUNCH=menace yarn dev:firefox",
     "format:check": "eslint ."
   },
   "devDependencies": {

--- a/src/components/Hyperchat.svelte
+++ b/src/components/Hyperchat.svelte
@@ -15,6 +15,8 @@
     // paramsTabId,
     // paramsFrameId,
     // paramsIsReplay,
+    getBrowser,
+    Browser,
     Theme,
     YoutubeEmojiRenderMode,
     chatUserActionsItems
@@ -258,13 +260,17 @@
       return;
     }
 
-    // const frameInfo = {
-    //   tabId: parseInt(paramsTabId),
-    //   frameId: parseInt(paramsFrameId)
-    // };
+    // ff doesn't support extension to content script raw messaging yet
+    if (getBrowser() == Browser.FIREFOX) {
+      const frameInfo = {
+        tabId: parseInt(paramsTabId),
+        frameId: parseInt(paramsFrameId)
+      };
 
-    // $port = chrome.runtime.connect();
-    $port = chrome.tabs.connect(parseInt(paramsTabId), { frameId: parseInt(paramsFrameId) });
+      $port = chrome.runtime.connect({ name: JSON.stringify(frameInfo) });
+    } else {
+      $port = chrome.tabs.connect(parseInt(paramsTabId), { frameId: parseInt(paramsFrameId) });
+    }
 
     $port?.onMessage.addListener(onPortMessage);
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -45,5 +45,6 @@
   "options_ui": {
     "page": "options.html",
     "open_in_tab": true
-  }
+  },
+  "{{chrome}}.incognito": "split"
 }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -24,7 +24,10 @@
       "all_frames": true
     }
   ],
-  "background": {
+  "{{firefox}}.background": {
+    "scripts": ["scripts/chat-background.ts"]
+  },
+  "{{chrome}}.background": {
     "service_worker": "scripts/chat-background.ts"
   },
   "action": {

--- a/utils/package.js
+++ b/utils/package.js
@@ -3,11 +3,11 @@ const { spawn } = require('child_process');
 const cmds = [
   'mkdir -p dist',
   'cd build',
-  'zip -9r ../dist/HyperChat-Firefox.zip .',
-  'cp ../dist/HyperChat-Firefox.zip ../dist/HyperChat-Chrome.zip',
-  'zip -d ../dist/HyperChat-Chrome.zip manifest.json',
-  'printf "@ manifest.chrome.json\\n@=manifest.json\\n" | zipnote -w ../dist/HyperChat-Chrome.zip',
-  'zip -d ../dist/HyperChat-Firefox.zip manifest.chrome.json'
+  'zip -9r ../dist/HyperChat-Chrome.zip .',
+  'cp ../dist/HyperChat-Chrome.zip ../dist/HyperChat-Firefox.zip',
+  'zip -d ../dist/HyperChat-Firefox.zip manifest.json',
+  'printf "@ manifest.firefox.json\\n@=manifest.json\\n" | zipnote -w ../dist/HyperChat-Firefox.zip',
+  'zip -d ../dist/HyperChat-Chrome.zip manifest.firefox.json'
 ];
 
 spawn(

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -30,7 +30,7 @@ export default defineConfig({
         'scripts/chat-interceptor.ts'
       ],
       disableAutoLaunch: process.env.HC_AUTOLAUNCH === undefined,
-      browser: process.env.BROWSER === undefined ? 'firefox' : process.env.BROWSER,
+      browser: process.env.BROWSER === undefined ? 'chrome' : process.env.BROWSER,
       webExtConfig: {
         startUrl: 'https://www.youtube.com/watch?v=jfKfPfyJRdk'
       }
@@ -46,15 +46,17 @@ export default defineConfig({
         dest: 'build/',
         transform: (content) => {
           const newManifest = JSON.parse(content.toString());
-          newManifest.incognito = 'split';
-          if ('scripts' in newManifest.background) {
+          if ('incognito' in newManifest) {
+            delete newManifest.incognito;
+          }
+          if ('service_worker' in newManifest.background) {
             newManifest.background = {
-              service_worker: newManifest.background.scripts[0]
+              scripts: [newManifest.background.service_worker]
             };
           }
           return JSON.stringify(newManifest, null, 2);
         },
-        rename: 'manifest.chrome.json'
+        rename: 'manifest.firefox.json'
       }]
     })
   ]

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -29,10 +29,10 @@ export default defineConfig({
         'hyperchat.html',
         'scripts/chat-interceptor.ts'
       ],
-      disableAutoLaunch: process.env.BROWSER === 'none',
+      disableAutoLaunch: process.env.HC_AUTOLAUNCH === undefined,
       browser: process.env.BROWSER === undefined ? 'firefox' : process.env.BROWSER,
       webExtConfig: {
-        startUrl: 'https://www.youtube.com/watch?v=5qap5aO4i9A'
+        startUrl: 'https://www.youtube.com/watch?v=jfKfPfyJRdk'
       }
     }),
     svelte({

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -30,7 +30,7 @@ export default defineConfig({
         'scripts/chat-interceptor.ts'
       ],
       disableAutoLaunch: process.env.BROWSER === 'none',
-      browser: process.env.BROWSER === 'none' ? undefined : process.env.BROWSER,
+      browser: process.env.BROWSER === undefined ? 'firefox' : process.env.BROWSER,
       webExtConfig: {
         startUrl: 'https://www.youtube.com/watch?v=5qap5aO4i9A'
       }
@@ -47,6 +47,11 @@ export default defineConfig({
         transform: (content) => {
           const newManifest = JSON.parse(content.toString());
           newManifest.incognito = 'split';
+          if ('scripts' in newManifest.background) {
+            newManifest.background = {
+              service_worker: newManifest.background.scripts[0]
+            };
+          }
           return JSON.stringify(newManifest, null, 2);
         },
         rename: 'manifest.chrome.json'


### PR DESCRIPTION
Adds support for MV3 in Firefox. Some things to note:

## Problems
1. ff does not support service workers in their mv3 "support"
2. ff does not support extension to content script channels in their mv3 "support"

## Solutions
1. use bg script for ff and service workers for chrome
	* implies that chrome and ff need completely different manifests (one is not superset of other)
	* introduce `yarn dev:firefox` and `yarn dev:chrome` and make `yarn start` alias for `yarn dev:chrome`
2. proxy extension to content script messages through background script for ff
	* unsure how long bg script for ff persists, I _think_ it should stay up as long as chat is active?
	* should give to ff beta testers to make sure it actually works over long intervals