### PR TITLE
Track Bytes Usage of Storage

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -48,6 +48,7 @@ module.exports = {
     ],
     'no-extra-semi': 'off',
     '@typescript-eslint/no-extra-semi': 'error',
+    '@typescript-eslint/no-floating-promises': 'off',
     'no-unused-vars': 'off',
     '@typescript-eslint/no-unused-vars': [
       'error',

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "devDependencies": {
     "@fullhuman/postcss-purgecss": "^4.0.3",
+    "@livetl/svelte-webext-stores": "^0.0.14",
     "@mdi/js": "^6.5.95",
     "@sveltejs/vite-plugin-svelte": "^1.0.0-next.34",
     "@tsconfig/svelte": "^2.0.1",
@@ -52,7 +53,6 @@
     "svelte-check": "^2.8.0",
     "svelte-preprocess": "^4.7.4",
     "svelte-waypoint": "^0.1.4",
-    "svelte-webext-stores": "^0.0.13",
     "tailwindcss": "^2.2.7",
     "typescript": "4.3.5",
     "vite": "2.9.14",

--- a/src/components/Hyperchat.svelte
+++ b/src/components/Hyperchat.svelte
@@ -261,7 +261,7 @@
     }
 
     // ff doesn't support extension to content script raw messaging yet
-    if (getBrowser() == Browser.FIREFOX) {
+    if (getBrowser() === Browser.FIREFOX) {
       const frameInfo = {
         tabId: parseInt(paramsTabId),
         frameId: parseInt(paramsFrameId)

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -46,5 +46,11 @@
     "page": "options.html",
     "open_in_tab": true
   },
-  "{{chrome}}.incognito": "split"
+  "{{chrome}}.incognito": "split",
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "{51076d9a-d4c2-11ed-af84-706655572bfb}",
+      "strict_min_version": "42.0"
+    }
+  }
 }

--- a/src/scripts/chat-background.ts
+++ b/src/scripts/chat-background.ts
@@ -1,5 +1,11 @@
 import { isLiveTL, Browser, getBrowser } from '../ts/chat-constants';
 
+const noUpdateKeys = new Set(['hc.bytes.used', 'hc.bytes.update']);
+const oneDay = 1000 * 60 * 60 * 24;
+
+const storageget = (key: string): any => chrome.storage.local.get(key).then(r => r[key]);
+const defaultTo0 = (value: any): number => isNaN(value) ? 0 : value;
+
 chrome.action.onClicked.addListener(() => {
   if (isLiveTL) {
     chrome.tabs.create({ url: 'https://livetl.app' }, () => {});
@@ -21,7 +27,7 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
 
 // ff doesn't support extension to content script raw messaging yet
 // so we proxy the messaging
-if (getBrowser() == Browser.FIREFOX) {
+if (getBrowser() === Browser.FIREFOX) {
   chrome.runtime.onConnect.addListener(hc => {
     // frameId and tabId should be int
     const { frameId, tabId } = JSON.parse(hc.name);
@@ -34,3 +40,46 @@ if (getBrowser() == Browser.FIREFOX) {
     });
   });
 }
+
+// see https://i.imgur.com/cGciqrX.png
+chrome.storage.local.onChanged.addListener(changes => {
+  let delta = 0;
+  for (const key of Object.keys(changes)) {
+    if (noUpdateKeys.has(key)) continue;
+    const { oldValue, newValue } = changes[key];
+    delta += oldValue === undefined
+      ? (key + JSON.stringify(newValue)).length
+      : JSON.stringify(newValue).length - JSON.stringify(oldValue).length;
+  }
+  if (delta === 0) return;
+
+  // avoid top-level async
+  // see https://stackoverflow.com/a/53024910
+  (async () => {
+    const toWrite = {};
+    const data = await Promise.all([
+      storageget('hc.bytes.used'),
+      storageget('hc.bytes.lastupdate')
+    ]);
+    let bytesused = defaultTo0(data[0]);
+    const lastupdate = defaultTo0(data[1]);
+    const now = Date.now();
+
+    // see https://i.imgur.com/S0i9oS4.png
+    //     https://i.imgur.com/PpBepQ0.png
+    if (now - lastupdate >= oneDay) {
+      // see https://bugzilla.mozilla.org/show_bug.cgi?id=1385832#c20
+      bytesused = new TextEncoder().encode(
+        Object.entries(await chrome.storage.local.get())
+          .map(([key, value]) => key + JSON.stringify(value))
+          .join('')
+      ).length;
+      toWrite['hc.bytes.lastupdate'] = now;
+    }
+
+    // storage transaction with 2 awaits -> potential data race???
+    toWrite['hc.bytes.used'] = bytesused + delta;
+    await chrome.storage.local.set(toWrite);
+  })();
+  return true;
+});

--- a/src/ts/storage.ts
+++ b/src/ts/storage.ts
@@ -79,3 +79,4 @@ export const currentProgress = writable(null as null | number);
 export const enableStickySuperchatBar = stores.addSyncStore('hc.enableStickySuperchatBar', true);
 export const enableHighlightedMentions = stores.addSyncStore('hc.enableHighlightedMentions', true);
 export const lastOpenedVersion = stores.addSyncStore('hc.lastOpenedVersion', '');
+export const bytesUsed = stores.addSyncStore('hc.bytes.used', 0);

--- a/src/ts/storage.ts
+++ b/src/ts/storage.ts
@@ -1,4 +1,4 @@
-import { webExtStores } from 'svelte-webext-stores';
+import { webExtStores } from '@livetl/svelte-webext-stores';
 import { derived, readable, writable } from 'svelte/store';
 import type { Writable } from 'svelte/store';
 import { getClient, AvailableLanguages } from 'iframe-translator';

--- a/yarn.lock
+++ b/yarn.lock
@@ -145,6 +145,11 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
+"@livetl/svelte-webext-stores@^0.0.14":
+  version "0.0.14"
+  resolved "https://registry.yarnpkg.com/@livetl/svelte-webext-stores/-/svelte-webext-stores-0.0.14.tgz#fc44603946bbf9b2d27ab8c7c15c2287920fbeaa"
+  integrity sha512-hd7uTNYHxbT8rkmuI8JSnKVpljXwmBdQ8bIaN/dgRyj08VifXLk95B8CDJSObU02sj8BeqYpAwHp9oL0uwbp+Q==
+
 "@mdi/js@^6.5.95":
   version "6.5.95"
   resolved "https://registry.yarnpkg.com/@mdi/js/-/js-6.5.95.tgz#2d895b013408f213252b77c30e0fdaaba6dc8b4b"
@@ -6892,11 +6897,6 @@ svelte-waypoint@^0.1.4:
   version "0.1.4"
   resolved "https://registry.npmjs.org/svelte-waypoint/-/svelte-waypoint-0.1.4.tgz"
   integrity sha512-UEqoXZjJeKj2sWlAIsBOFjxjMn+KP8aFCc/zjdmZi1cCOE59z6T2C+I6ZaAf8EmNQqNzfZVB/Lci4Ci9spzXAw==
-
-svelte-webext-stores@^0.0.13:
-  version "0.0.13"
-  resolved "https://registry.yarnpkg.com/svelte-webext-stores/-/svelte-webext-stores-0.0.13.tgz#de0baf2188d2d1713aff847c57565199508af217"
-  integrity sha512-Ru4k67E1gj3lTvZXvHeFECn1YzJF1ZNYE7X4F7UQFxytOEqCaVyQMSnE8gGKU1+gpAJUAD6O69ZSEsGStvimUg==
 
 svelte@^3.31.2, svelte@^3.49.0:
   version "3.49.0"


### PR DESCRIPTION
Add custom mechanism to track bytes usage of chrome storage because firefox hasn't implemented getBytesUsed on `chrome.storage.local`

![explainer](https://i.imgur.com/cGciqrX.png)
![explainer pt 2](https://i.imgur.com/S0i9oS4.png)

We can add a hook for exceeding storage quota (that could be user-controlled) later either by:
* send a message from bg script when it sees bytesused > quota
* subscribe to bytesused store and see if it exceeds a limit `$: if ($bytesUsed > quota) { ...`

so such a hook is not needed in this pr.