### PR TITLE
Update z-index to prevent chat from showing up over 'rules' dialog

### DIFF
--- a/src/components/HyperchatButton.svelte
+++ b/src/components/HyperchatButton.svelte
@@ -65,7 +65,7 @@
 
 <style>
   :global(div#contents.style-scope.yt-live-chat-renderer) {
-    z-index: 100;
+    z-index: 2;
   }
 
   #hc-buttons {


### PR DESCRIPTION
Fixes #139 

Unsure if this style override is even necessary anymore but the rules dialog uses z-index 3 so this will paper over the issue for now, and I don't believe it reintroduces #134/etc.

Tested with Hyperchat enabled and disabled, handles both cases for the linked issue.

Alternatives:
Overriding the rules dialog's z-index to be 101 or something instead of doing this just seems like it will create a cascading set of overrides for stock YT chat behavior, which doesn't seem like the play.