### PR TITLE
Show YT's AI chat summary in a 'pinned'-style box if it is present

### DIFF
--- a/src/components/ChatSummary.svelte
+++ b/src/components/ChatSummary.svelte
@@ -40,7 +40,7 @@
             {/if}
           </Icon>
         </span>
-        {#each summary.header as run}
+        {#each summary.item.header as run}
           {#if run.type === 'text'}
             <span class="align-middle">{run.text}</span>
           {/if}
@@ -61,10 +61,10 @@
     </div>
     {#if !shorten && !dismissed}
       <div class="mt-1 whitespace-pre-line" transition:slide|local={{ duration: 300 }}>
-        <MessageRun runs={summary.subheader} deleted forceDark forceTLColor={Theme.DARK}/>
+        <MessageRun runs={summary.item.subheader} deleted forceDark forceTLColor={Theme.DARK}/>
       </div>
       <div class="mt-1 whitespace-pre-line" transition:slide|local={{ duration: 300 }}>
-        <MessageRun runs={summary.summary} forceDark forceTLColor={Theme.DARK}/>
+        <MessageRun runs={summary.item.message} forceDark forceTLColor={Theme.DARK}/>
       </div>
     {/if}
   </div>

--- a/src/components/ChatSummary.svelte
+++ b/src/components/ChatSummary.svelte
@@ -61,6 +61,9 @@
     </div>
     {#if !shorten && !dismissed}
       <div class="mt-1 whitespace-pre-line" transition:slide|local={{ duration: 300 }}>
+        <MessageRun runs={summary.subheader} deleted forceDark forceTLColor={Theme.DARK}/>
+      </div>
+      <div class="mt-1 whitespace-pre-line" transition:slide|local={{ duration: 300 }}>
         <MessageRun runs={summary.summary} forceDark forceTLColor={Theme.DARK}/>
       </div>
     {/if}

--- a/src/components/ChatSummary.svelte
+++ b/src/components/ChatSummary.svelte
@@ -1,0 +1,68 @@
+<script lang="ts">
+  import { slide, fade } from 'svelte/transition';
+  import MessageRun from './MessageRuns.svelte';
+  import Tooltip from './common/Tooltip.svelte';
+  import Icon from 'smelte/src/components/Icon';
+  import { Theme } from '../ts/chat-constants';
+  import { createEventDispatcher } from 'svelte';
+
+  export let summary: Ytc.ParsedSummary;
+
+  let dismissed = false;
+  let shorten = false;
+  const classes = 'rounded inline-flex flex-col overflow-visible ' +
+   'bg-secondary-900 p-2 w-full text-white z-10 shadow';
+
+  const onShorten = () => { shorten = !shorten; };
+
+  $: if (summary) {
+    dismissed = false;
+    shorten = false;
+  }
+
+  const dispatch = createEventDispatcher();
+  $: dismissed, shorten, dispatch('resize');
+</script>
+
+{#if !dismissed}
+  <div
+    class={classes}
+    transition:fade={{ duration: 250 }}
+  >
+    <div class="flex flex-row items-center cursor-pointer" on:click={onShorten}>
+      <div class="font-medium tracking-wide text-white flex-1">
+        <span class="mr-1 inline-block" style="transform: translateY(3px);">
+          <Icon small>
+            {#if shorten}
+              expand_more
+            {:else}
+              expand_less
+            {/if}
+          </Icon>
+        </span>
+        {#each summary.header as run}
+          {#if run.type === 'text'}
+            <span class="align-middle">{run.text}</span>
+          {/if}
+        {/each}
+      </div>
+      <div class="flex-none self-end" style="transform: translateY(3px);">
+        <Tooltip offsetY={0} small>
+          <Icon
+            slot="activator"
+            class="cursor-pointer text-lg"
+            on:click={() => { dismissed = true; }}
+          >
+            close
+          </Icon>
+          Dismiss
+        </Tooltip>
+      </div>
+    </div>
+    {#if !shorten && !dismissed}
+      <div class="mt-1 whitespace-pre-line" transition:slide|local={{ duration: 300 }}>
+        <MessageRun runs={summary.summary} forceDark forceTLColor={Theme.DARK}/>
+      </div>
+    {/if}
+  </div>
+{/if}

--- a/src/components/Hyperchat.svelte
+++ b/src/components/Hyperchat.svelte
@@ -29,6 +29,7 @@
     showUsernames,
     showTimestamps,
     showUserBadges,
+    showChatSummary,
     refreshScroll,
     emojiRenderMode,
     useSystemEmojis,
@@ -398,9 +399,9 @@
         </div>
       {/each}
     </div>
-    {#if summary || pinned}
+    {#if (summary && $showChatSummary) || pinned}
       <div class="absolute top-0 w-full" bind:this={topBar}>
-        {#if summary}
+        {#if summary && $showChatSummary}
           <div class="mx-1.5 mt-1.5">
             <ChatSummary summary={summary} on:resize={topBarResized} />
           </div>

--- a/src/components/Hyperchat.svelte
+++ b/src/components/Hyperchat.svelte
@@ -6,6 +6,7 @@
   import WelcomeMessage from './WelcomeMessage.svelte';
   import Message from './Message.svelte';
   import PinnedMessage from './PinnedMessage.svelte';
+  import ChatSummary from './ChatSummary.svelte';
   import PaidMessage from './PaidMessage.svelte';
   import MembershipItem from './MembershipItem.svelte';
   import ReportBanDialog from './ReportBanDialog.svelte';
@@ -53,6 +54,7 @@
   let messageActions: (Chat.MessageAction | Welcome)[] = [];
   const messageKeys = new Set<string>();
   let pinned: Ytc.ParsedPinned | null;
+  let summary: Ytc.ParsedSummary | null;
   let div: HTMLElement;
   let isAtBottom = true;
   let truncateInterval: number;
@@ -182,6 +184,9 @@
         break;
       case 'delete':
         onDelete(action.deletion);
+        break;
+      case 'summary':
+        summary = action;
         break;
       case 'pin':
         pinned = action;
@@ -393,11 +398,18 @@
         </div>
       {/each}
     </div>
-    {#if pinned}
+    {#if summary || pinned}
       <div class="absolute top-0 w-full" bind:this={topBar}>
-        <div class="mx-1.5 mt-1.5">
-          <PinnedMessage pinned={pinned} on:resize={topBarResized} />
-        </div>
+        {#if summary}
+          <div class="mx-1.5 mt-1.5">
+            <ChatSummary summary={summary} on:resize={topBarResized} />
+          </div>
+        {/if}
+        {#if pinned}
+          <div class="mx-1.5 mt-1.5">
+            <PinnedMessage pinned={pinned} on:resize={topBarResized} />
+          </div>
+        {/if}
       </div>
     {/if}
     {#if !isAtBottom}

--- a/src/components/settings/InterfaceSettings.svelte
+++ b/src/components/settings/InterfaceSettings.svelte
@@ -11,7 +11,8 @@
     useSystemEmojis,
     isDark,
     enableStickySuperchatBar,
-    enableHighlightedMentions
+    enableHighlightedMentions,
+    showChatSummary
   } from '../../ts/storage';
   import { themeItems, emojiRenderItems } from '../../ts/chat-constants';
   import Card from '../common/Card.svelte';
@@ -59,6 +60,7 @@
   <Checkbox name="Show timestamps" store={showTimestamps} />
   <Checkbox name="Show usernames" store={showUsernames} />
   <Checkbox name="Show user badges" store={showUserBadges} />
+  <Checkbox name="Show YouTube's chat summary" store={showChatSummary} />
   <Checkbox name="Highlight mentions" store={enableHighlightedMentions} />
 </Card>
 

--- a/src/components/settings/InterfaceSettings.svelte
+++ b/src/components/settings/InterfaceSettings.svelte
@@ -60,7 +60,7 @@
   <Checkbox name="Show timestamps" store={showTimestamps} />
   <Checkbox name="Show usernames" store={showUsernames} />
   <Checkbox name="Show user badges" store={showUserBadges} />
-  <Checkbox name="Show YouTube's chat summary" store={showChatSummary} />
+  <Checkbox name="Show experimental YouTube chat summaries" store={showChatSummary} />
   <Checkbox name="Highlight mentions" store={enableHighlightedMentions} />
 </Card>
 

--- a/src/components/settings/InterfaceSettings.svelte
+++ b/src/components/settings/InterfaceSettings.svelte
@@ -60,7 +60,7 @@
   <Checkbox name="Show timestamps" store={showTimestamps} />
   <Checkbox name="Show usernames" store={showUsernames} />
   <Checkbox name="Show user badges" store={showUserBadges} />
-  <Checkbox name="Show experimental YouTube chat summaries" store={showChatSummary} />
+  <Checkbox name="Show experimental chat summaries by YouTube" store={showChatSummary} />
   <Checkbox name="Highlight mentions" store={enableHighlightedMentions} />
 </Card>
 

--- a/src/ts/chat-parser.ts
+++ b/src/ts/chat-parser.ts
@@ -102,9 +102,6 @@ const parseChatSummary = (renderer: Ytc.AddChatItem, isEphemeral: boolean, banne
       subheader: subheader,
       message: splitRuns[2],
     },
-    icon: baseRenderer.icon && {
-      iconType: baseRenderer.icon?.iconType.toLowerCase(),
-    },
     id: baseRenderer.liveChatSummaryId,
     showtime: isEphemeral ? (bannerTimeoutMs / 1000) : 0,
   };

--- a/src/ts/chat-parser.ts
+++ b/src/ts/chat-parser.ts
@@ -77,7 +77,7 @@ const splitRunsByNewline = (runs: Ytc.ParsedRun[], maxSplit: number = -1): Ytc.P
   return output;
 }
 
-const parseChatSummary = (renderer: Ytc.AddChatItem, isEphemeral: boolean | undefined, bannerTimeoutMs: number | undefined): Ytc.ParsedSummary | undefined => {
+const parseChatSummary = (renderer: Ytc.AddChatItem, isEphemeral: boolean, bannerTimeoutMs: number): Ytc.ParsedSummary | undefined => {
   if (!renderer.liveChatBannerChatSummaryRenderer) {
     return;
   }
@@ -106,7 +106,7 @@ const parseChatSummary = (renderer: Ytc.AddChatItem, isEphemeral: boolean | unde
       iconType: baseRenderer.icon?.iconType.toLowerCase(),
     },
     id: baseRenderer.liveChatSummaryId,
-    showtime: isEphemeral ? (bannerTimeoutMs ?? 0) / 1000 : 0,
+    showtime: isEphemeral ? (bannerTimeoutMs / 1000) : 0,
   };
   return item;
 }
@@ -236,7 +236,7 @@ const parseMessageDeletedAction = (action: Ytc.MessageDeletedAction): Ytc.Parsed
 const parseBannerAction = (action: Ytc.AddPinnedAction): Ytc.ParsedPinned | Ytc.ParsedSummary | undefined => {
   const baseRenderer = action.bannerRenderer.liveChatBannerRenderer;
   if (baseRenderer.contents.liveChatBannerChatSummaryRenderer) {
-    return parseChatSummary(baseRenderer.contents, action.bannerProperties?.isEphemeral, action.bannerProperties?.bannerTimeoutMs);
+    return parseChatSummary(baseRenderer.contents, action.bannerProperties?.isEphemeral ?? false, action.bannerProperties?.bannerTimeoutMs ?? 0);
   }
   const parsedContents = parseAddChatItemAction(
     { item: baseRenderer.contents }, true

--- a/src/ts/chat-parser.ts
+++ b/src/ts/chat-parser.ts
@@ -88,7 +88,7 @@ const parseChatSummary = (renderer: Ytc.AddChatItem, isEphemeral: boolean, banne
   const subheader = splitRuns[1].map(run => {
     if (run.type === 'text') {
       // turn subheader into a link to YT's support page detailing the AI summary feature
-      return { type: 'link', text: run.text, url: 'https://support.google.com/youtube/thread/18138167?hl=en&msgid=284199217' } as Ytc.ParsedLinkRun;
+      return { type: 'link', text: run.text, url: 'https://support.google.com/youtube/thread/18138167?msgid=284199217' } as Ytc.ParsedLinkRun;
     } else {
       return run;
     }

--- a/src/ts/chat-parser.ts
+++ b/src/ts/chat-parser.ts
@@ -81,11 +81,18 @@ const parseChatSummary = (renderer: Ytc.AddChatItem, isEphemeral: boolean | unde
   const baseRenderer = renderer.liveChatBannerChatSummaryRenderer!;
   const runs = parseMessageRuns(renderer.liveChatBannerChatSummaryRenderer?.chatSummary.runs);
   const splitRuns = splitRunsByNewline(runs, 2);
+  const subheader = splitRuns[1].map(run => {
+    if (run.type === 'text') {
+      return { type: 'link', text: run.text, url: 'https://support.google.com/youtube/thread/18138167?hl=en&msgid=284199217' } as Ytc.ParsedLinkRun;
+    } else {
+      return run;
+    }
+  });
   const item: Ytc.ParsedSummary = {
     type: 'summary',
     item: {
       header: splitRuns[0],
-      subheader: splitRuns[1],
+      subheader: subheader,
       message: splitRuns[2],
     },
     icon: baseRenderer.icon && {

--- a/src/ts/chat-parser.ts
+++ b/src/ts/chat-parser.ts
@@ -81,6 +81,10 @@ const parseChatSummary = (renderer: Ytc.AddChatItem, isEphemeral: boolean | unde
   const baseRenderer = renderer.liveChatBannerChatSummaryRenderer!;
   const runs = parseMessageRuns(renderer.liveChatBannerChatSummaryRenderer?.chatSummary.runs);
   const splitRuns = splitRunsByNewline(runs, 2);
+  if (splitRuns.length < 3) {
+    // YT probably changed the format, refuse to do anything to avoid breaking
+    return;
+  }
   const subheader = splitRuns[1].map(run => {
     if (run.type === 'text') {
       return { type: 'link', text: run.text, url: 'https://support.google.com/youtube/thread/18138167?hl=en&msgid=284199217' } as Ytc.ParsedLinkRun;

--- a/src/ts/chat-parser.ts
+++ b/src/ts/chat-parser.ts
@@ -90,6 +90,7 @@ const parseChatSummary = (renderer: Ytc.AddChatItem, isEphemeral: boolean, banne
   }
   const subheader = splitRuns[1].map(run => {
     if (run.type === 'text') {
+      // turn subheader into a link to YT's support page detailing the AI summary feature
       return { type: 'link', text: run.text, url: 'https://support.google.com/youtube/thread/18138167?hl=en&msgid=284199217' } as Ytc.ParsedLinkRun;
     } else {
       return run;

--- a/src/ts/chat-parser.ts
+++ b/src/ts/chat-parser.ts
@@ -61,21 +61,18 @@ const parseMessageRuns = (runs?: Ytc.MessageRun[]): Ytc.ParsedRun[] => {
   return parsedRuns;
 };
 
-const splitRunsByNewline = (runs: Ytc.ParsedRun[], maxSplit: number = -1): Ytc.ParsedRun[][] => {
-  // takes an array of runs, finds newline-only runs, and splits the array by them, up to maxSplit times
-  let currSplit = 0;
-  const output: Ytc.ParsedRun[][] = [];
-  output.push(runs.reduce((acc: Ytc.ParsedRun[], run: Ytc.ParsedRun) => {
-    if (run.type === 'text' && run.text === '\n' && (maxSplit == -1 || currSplit < maxSplit)) {
-      currSplit++;
-      output.push(acc);
-      return [];
+// takes an array of runs, finds newline-only runs, and splits the array by them, up to maxSplit times
+// final output will have maximum length of maxSplit + 1
+// maxSplit = -1 will have no limit for splits
+const splitRunsByNewline = (runs: Ytc.ParsedRun[], maxSplit: number = -1): Ytc.ParsedRun[][] => 
+  runs.reduce((acc: Ytc.ParsedRun[][], run: Ytc.ParsedRun) => {
+    if (run.type === 'text' && run.text === '\n' && (maxSplit == -1 || acc.length <= maxSplit)) {
+      acc.push([]);
+    } else {
+      acc[acc.length - 1].push(run);
     }
-    acc.push(run);
     return acc;
-  }, []));
-  return output;
-}
+  }, [[]]);
 
 const parseChatSummary = (renderer: Ytc.AddChatItem, isEphemeral: boolean, bannerTimeoutMs: number): Ytc.ParsedSummary | undefined => {
   if (!renderer.liveChatBannerChatSummaryRenderer) {

--- a/src/ts/chat-parser.ts
+++ b/src/ts/chat-parser.ts
@@ -64,12 +64,10 @@ const parseMessageRuns = (runs?: Ytc.MessageRun[]): Ytc.ParsedRun[] => {
 const parseChatSummary = (renderer: Ytc.AddChatItem, isEphemeral: boolean | undefined, bannerTimeoutMs: number | undefined): Ytc.ParsedSummary | undefined => {
   const baseRenderer = renderer.liveChatBannerChatSummaryRenderer!;
   const runs = parseMessageRuns(renderer.liveChatBannerChatSummaryRenderer?.chatSummary.runs);
-  if (runs[2].type === 'text') {
-    runs[2].text = '(' + runs[2].text + ')';
-  }
   const item: Ytc.ParsedSummary = {
     type: 'summary',
-    header: runs.slice(0, 3),
+    header: [runs[0]],
+    subheader: [runs[2]],
     summary: runs.slice(4),
     icon: baseRenderer.icon && {
       iconType: baseRenderer.icon?.iconType.toLowerCase(),

--- a/src/ts/chat-parser.ts
+++ b/src/ts/chat-parser.ts
@@ -78,6 +78,9 @@ const splitRunsByNewline = (runs: Ytc.ParsedRun[], maxSplit: number = -1): Ytc.P
 }
 
 const parseChatSummary = (renderer: Ytc.AddChatItem, isEphemeral: boolean | undefined, bannerTimeoutMs: number | undefined): Ytc.ParsedSummary | undefined => {
+  if (!renderer.liveChatBannerChatSummaryRenderer) {
+    return;
+  }
   const baseRenderer = renderer.liveChatBannerChatSummaryRenderer!;
   const runs = parseMessageRuns(renderer.liveChatBannerChatSummaryRenderer?.chatSummary.runs);
   const splitRuns = splitRunsByNewline(runs, 2);

--- a/src/ts/storage.ts
+++ b/src/ts/storage.ts
@@ -49,6 +49,7 @@ export const showProfileIcons = stores.addSyncStore('hc.messages.showProfileIcon
 export const showUsernames = stores.addSyncStore('hc.messages.showUsernames', true);
 export const showTimestamps = stores.addSyncStore('hc.messages.showTimestamps', false);
 export const showUserBadges = stores.addSyncStore('hc.messages.showUserBadges', true);
+export const showChatSummary = stores.addSyncStore('hc.messages.showChatSummary', true);
 export const lastClosedVersion = stores.addSyncStore('hc.lastClosedVersion', '');
 export const showOnlyMemberChat = stores.addSyncStore('hc.showOnlyMemberChat', false);
 export const emojiRenderMode = stores.addSyncStore('hc.emojiRenderMode', YoutubeEmojiRenderMode.SHOW_ALL);

--- a/src/ts/typings/ytc.d.ts
+++ b/src/ts/typings/ytc.d.ts
@@ -88,6 +88,10 @@ declare namespace Ytc {
         };
       };
     };
+    bannerProperties?: {
+      isEphemeral: boolean;
+      bannerTimeoutMs: number;
+    }
   }
 
   interface AddTickerAction {
@@ -227,6 +231,15 @@ declare namespace Ytc {
     };
   }
 
+  interface ChatSummaryRenderer {
+    liveChatSummaryId: string;
+    chatSummary: RunsObj;
+    icon?: {
+      /** Unlocalized string */
+      iconType: string;
+    };
+  }
+
   interface PlaceholderRenderer { // No idea what the purpose of this is
     id: string;
     timestampUsec: IntString;
@@ -248,6 +261,8 @@ declare namespace Ytc {
     liveChatSponsorshipsGiftPurchaseAnnouncementRenderer?: MembershipGiftPurchaseRenderer;
     /** Membership gift redemption */
     liveChatSponsorshipsGiftRedemptionAnnouncementRenderer?: TextMessageRenderer;
+    /** AI Chat Summary */
+    liveChatBannerChatSummaryRenderer?: ChatSummaryRenderer;
     /** ??? */
     liveChatPlaceholderItemRenderer?: PlaceholderRenderer;
   }
@@ -365,13 +380,25 @@ declare namespace Ytc {
     };
   }
 
+  interface ParsedSummary {
+    type: 'summary';
+    header: ParsedRun[];
+    summary: ParsedRun[];
+    id: string;
+    icon?: {
+      /** Unlocalized string */
+      iconType: string;
+    };
+    showtime: number;
+  }
+
   interface ParsedTicker extends ParsedMessage {
     type: 'ticker';
     tickerDuration: number;
     detailText?: string;
   }
 
-  type ParsedMisc = ParsedPinned | { type: 'unpin'};
+  type ParsedMisc = ParsedPinned | ParsedSummary | { type: 'unpin' };
 
   type ParsedTimedItem = ParsedMessage | ParsedTicker;
 

--- a/src/ts/typings/ytc.d.ts
+++ b/src/ts/typings/ytc.d.ts
@@ -382,9 +382,11 @@ declare namespace Ytc {
 
   interface ParsedSummary {
     type: 'summary';
-    header: ParsedRun[];
-    subheader: ParsedRun[];
-    summary: ParsedRun[];
+    item: {
+      header: ParsedRun[];
+      subheader: ParsedRun[];
+      message: ParsedRun[];
+    };
     id: string;
     icon?: {
       /** Unlocalized string */

--- a/src/ts/typings/ytc.d.ts
+++ b/src/ts/typings/ytc.d.ts
@@ -383,6 +383,7 @@ declare namespace Ytc {
   interface ParsedSummary {
     type: 'summary';
     header: ParsedRun[];
+    subheader: ParsedRun[];
     summary: ParsedRun[];
     id: string;
     icon?: {

--- a/src/ts/typings/ytc.d.ts
+++ b/src/ts/typings/ytc.d.ts
@@ -388,10 +388,6 @@ declare namespace Ytc {
       message: ParsedRun[];
     };
     id: string;
-    icon?: {
-      /** Unlocalized string */
-      iconType: string;
-    };
     showtime: number;
   }
 


### PR DESCRIPTION
* Uses subheader as a link to [Google's support site for AI summaries](https://support.google.com/youtube/thread/18138167?hl=en&msgid=284199217)
* Dismissable and collapsible like pinned messages, but unlike stock YT it does not auto-dismiss after 12 seconds
* Setting to hide it entirely (will update its visibility based on setting immediately without refresh)
* Tested on ffox and on mv3 branch with chrome.

It's not perfect (icon and showtime fields remain unused right now) but it's pretty functional. Collapsing and dismissing both work as intended.
There are some hacky bits involved already to split the runs into header vs subheader vs message, so better ways to handle that would be nice, but YT's format for this action isn't ideal.
I tried adding the iconType stuff, but it resulted in the header being offset by the size of the _name_ of the icon. Was not sure how to resolve.
As far as I can tell YT never sends this as a part of live chat data, only when first loading the chat, but hopefully it works the same if they do add it to live chat data as well.
I did _not_ hook it up to dismiss when YT sends 'unpin' action, as a heads up.

# Screenshots:
<details>
<summary>Setting</summary>
<img width="323" alt="Screenshot 2024-09-17 at 6 24 26 PM" src="https://github.com/user-attachments/assets/0466fd7c-5d4e-4944-8163-6a9ce9351d41">
</details>

<details>
<summary>
With subheader as a link to https://support.google.com/youtube/thread/18138167?hl=en&msgid=284199217 :
</summary>
<img width="338" alt="Screenshot 2024-09-17 at 5 52 56 PM" src="https://github.com/user-attachments/assets/0939268f-2638-4936-9d4c-86aee2927b38">
</details>

<details>
<summary>
Before subheader change, but showing behavior alongside pinned msg:
</summary>
<img width="333" alt="Screenshot 2024-09-17 at 6 05 58 AM" src="https://github.com/user-attachments/assets/9c8c8645-7ad4-421d-9ea1-cc5dc8c507c4">
<img width="334" alt="Screenshot 2024-09-17 at 6 04 22 AM" src="https://github.com/user-attachments/assets/56f0ea13-c4bb-4058-b078-c2852e20bea4">
</details>


