### PR TITLE
Auto-collapse Chat Summary banner after bannerTimeoutMs

### DIFF
--- a/src/components/ChatSummary.svelte
+++ b/src/components/ChatSummary.svelte
@@ -10,14 +10,24 @@
 
   let dismissed = false;
   let shorten = false;
+  let autoHideTimeout: NodeJS.Timeout | null = null;
   const classes = 'rounded inline-flex flex-col overflow-visible ' +
    'bg-secondary-900 p-2 w-full text-white z-10 shadow';
 
-  const onShorten = () => { shorten = !shorten; };
+  const onShorten = () => { 
+    shorten = !shorten;
+    if (autoHideTimeout) {
+      clearTimeout(autoHideTimeout);
+      autoHideTimeout = null;
+    }
+   };
 
   $: if (summary) {
     dismissed = false;
     shorten = false;
+    if (summary.showtime) {
+      autoHideTimeout = setTimeout(() => { shorten = true; }, summary.showtime);
+    }
   }
 
   const dispatch = createEventDispatcher();

--- a/src/ts/chat-parser.ts
+++ b/src/ts/chat-parser.ts
@@ -101,7 +101,7 @@ const parseChatSummary = (renderer: Ytc.AddChatItem, isEphemeral: boolean, banne
       message: splitRuns[2],
     },
     id: baseRenderer.liveChatSummaryId,
-    showtime: isEphemeral ? (bannerTimeoutMs / 1000) : 0,
+    showtime: isEphemeral ? bannerTimeoutMs : 0,
   };
   return item;
 }


### PR DESCRIPTION
YouTube by default will dismiss the Chat Summary banner after bannerTimeoutMs (usually 12 seconds). Hyperchat currently does not dismiss the banner at all.
This change picks up YT's behavior, but instead of dismissing the banner, just collapses it.
The timer for collapsing the banner is cancelled if the banner gets manually collapsed.

This also changes summary.showtime from seconds to milliseconds.

Tested in mv3 on chrome, assuming ffox will work fine on master.