### PR TITLE
Implement rudimentary redirect banner

### DIFF
--- a/src/components/Hyperchat.svelte
+++ b/src/components/Hyperchat.svelte
@@ -58,6 +58,31 @@
   let pinned: Ytc.ParsedPinned | null;
   let summary: Ytc.ParsedSummary | null;
   let redirect: Ytc.ParsedRedirect | null;
+  // = {
+  //   type: 'redirect',
+  //   item: {
+  //     message: [
+  //       {
+  //         type: 'text',
+  //         text: 'Don\'t miss out! People are going to watch something from someone',
+  //       },
+  //     ],
+  //     profileIcon: {
+  //       src: 'https://picsum.photos/32',
+  //       alt: 'Redirect profile photo',
+  //     },
+  //     action: {
+  //       url: 'https://example.com/',
+  //       text: [
+  //         {
+  //           type: 'text',
+  //           text: 'Go Now',
+  //         },
+  //       ],
+  //     },
+  //   },
+  //   showtime: 5000,
+  // };
   $: hasBanner = pinned || redirect || (summary && $showChatSummary);
   let div: HTMLElement;
   let isAtBottom = true;

--- a/src/components/Hyperchat.svelte
+++ b/src/components/Hyperchat.svelte
@@ -7,6 +7,7 @@
   import Message from './Message.svelte';
   import PinnedMessage from './PinnedMessage.svelte';
   import ChatSummary from './ChatSummary.svelte';
+  import RedirectBanner from './RedirectBanner.svelte';
   import PaidMessage from './PaidMessage.svelte';
   import MembershipItem from './MembershipItem.svelte';
   import ReportBanDialog from './ReportBanDialog.svelte';
@@ -46,7 +47,6 @@
     ytDark
   } from '../ts/storage';
   import { version } from '../manifest.json';
-  import RedirectBanner from './RedirectBanner.svelte';
 
   const welcome = { welcome: true, message: { messageId: 'welcome' } };
   type Welcome = typeof welcome;

--- a/src/components/Hyperchat.svelte
+++ b/src/components/Hyperchat.svelte
@@ -46,6 +46,7 @@
     ytDark
   } from '../ts/storage';
   import { version } from '../manifest.json';
+  import RedirectBanner from './RedirectBanner.svelte';
 
   const welcome = { welcome: true, message: { messageId: 'welcome' } };
   type Welcome = typeof welcome;
@@ -56,6 +57,8 @@
   const messageKeys = new Set<string>();
   let pinned: Ytc.ParsedPinned | null;
   let summary: Ytc.ParsedSummary | null;
+  let redirect: Ytc.ParsedRedirect | null;
+  $: hasBanner = pinned || redirect || (summary && $showChatSummary);
   let div: HTMLElement;
   let isAtBottom = true;
   let truncateInterval: number;
@@ -188,6 +191,9 @@
         break;
       case 'summary':
         summary = action;
+        break;
+      case 'redirect':
+        redirect = action;
         break;
       case 'pin':
         pinned = action;
@@ -399,11 +405,16 @@
         </div>
       {/each}
     </div>
-    {#if (summary && $showChatSummary) || pinned}
+    {#if hasBanner}
       <div class="absolute top-0 w-full" bind:this={topBar}>
         {#if summary && $showChatSummary}
           <div class="mx-1.5 mt-1.5">
             <ChatSummary summary={summary} on:resize={topBarResized} />
+          </div>
+        {/if}
+        {#if redirect}
+          <div class="mx-1.5 mt-1.5">
+            <RedirectBanner redirect={redirect} on:resize={topBarResized} />
           </div>
         {/if}
         {#if pinned}

--- a/src/components/MessageRuns.svelte
+++ b/src/components/MessageRuns.svelte
@@ -45,7 +45,13 @@
         {#if deleted}
           <span>{run.text}</span>
         {:else}
-          <TranslatedMessage text={run.text} {forceTLColor} />
+          {#if run.styles?.includes('bold')}
+            <strong>
+              <TranslatedMessage text={run.text} {forceTLColor} />
+            </strong>
+          {:else}
+            <TranslatedMessage text={run.text} {forceTLColor} />
+          {/if}
         {/if}
       {:else if run.type === 'link'}
         <a

--- a/src/components/RedirectBanner.svelte
+++ b/src/components/RedirectBanner.svelte
@@ -1,0 +1,88 @@
+<script lang="ts">
+  import { slide, fade } from 'svelte/transition';
+  import MessageRun from './MessageRuns.svelte';
+  import Tooltip from './common/Tooltip.svelte';
+  import Icon from 'smelte/src/components/Icon';
+  import { Theme } from '../ts/chat-constants';
+  import { createEventDispatcher } from 'svelte';
+  import { showProfileIcons } from '../ts/storage';
+  import Button from 'smelte/src/components/Button';
+
+  export let redirect: Ytc.ParsedRedirect;
+
+  let dismissed = false;
+  let shorten = false;
+  let autoHideTimeout: NodeJS.Timeout | null = null;
+  const classes = 'rounded inline-flex flex-col overflow-visible ' +
+   'bg-secondary-900 p-2 w-full text-white z-10 shadow';
+
+  const onShorten = () => { 
+    shorten = !shorten;
+    if (autoHideTimeout) {
+      clearTimeout(autoHideTimeout);
+      autoHideTimeout = null;
+    }
+  };
+
+  $: if (redirect) {
+    dismissed = false;
+    shorten = false;
+    if (redirect.showtime) {
+      autoHideTimeout = setTimeout(() => { shorten = true; }, redirect.showtime);
+    }
+  }
+
+  const dispatch = createEventDispatcher();
+  $: dismissed, shorten, dispatch('resize');
+</script>
+
+{#if !dismissed}
+  <div
+    class={classes}
+    transition:fade={{ duration: 250 }}
+  >
+    <div class="flex flex-row items-center cursor-pointer" on:click={onShorten}>
+      <div class="font-medium tracking-wide text-white flex-1">
+        <span class="mr-1 inline-block" style="transform: translateY(3px);">
+          <Icon small>
+            {#if shorten}
+              expand_more
+            {:else}
+              expand_less
+            {/if}
+          </Icon>
+        </span>
+        <span class="align-middle">Redirect Notice</span>
+      </div>
+      <div class="flex-none self-end" style="transform: translateY(3px);">
+        <Tooltip offsetY={0} small>
+          <Icon
+            slot="activator"
+            class="cursor-pointer text-lg"
+            on:click={() => { dismissed = true; }}
+          >
+            close
+          </Icon>
+          Dismiss
+        </Tooltip>
+      </div>
+    </div>
+    {#if !shorten && !dismissed}
+      <div class="mt-1 whitespace-pre-line" transition:slide|local={{ duration: 300 }}>
+        {#if $showProfileIcons}
+          <img
+            class="h-5 w-5 inline align-middle rounded-full flex-none"
+            src={redirect.item.profileIcon.src}
+            alt={redirect.item.profileIcon.alt}
+          />
+        {/if}
+        <MessageRun runs={redirect.item.message} forceDark forceTLColor={Theme.DARK}/>
+      </div>
+      <div class="mt-1 whitespace-pre-line" transition:slide|local={{ duration: 300 }}>
+        <Button href={redirect.item.action.url} target="_blank" small>
+          <MessageRun runs={redirect.item.action.text} forceDark forceTLColor={Theme.DARK}/>
+        </Button>
+      </div>
+    {/if}
+  </div>
+{/if}

--- a/src/components/RedirectBanner.svelte
+++ b/src/components/RedirectBanner.svelte
@@ -68,7 +68,7 @@
       </div>
     </div>
     {#if !shorten && !dismissed}
-      <div class="mt-1 whitespace-pre-line" transition:slide|local={{ duration: 300 }}>
+      <div class="inline-flex flex-row gap-2 break-words w-full overflow-visible" transition:slide|local={{ duration: 300 }}>
         {#if $showProfileIcons}
           <img
             class="h-5 w-5 inline align-middle rounded-full flex-none"

--- a/src/components/RedirectBanner.svelte
+++ b/src/components/RedirectBanner.svelte
@@ -68,7 +68,7 @@
       </div>
     </div>
     {#if !shorten && !dismissed}
-      <div class="inline-flex flex-row gap-2 break-words w-full overflow-visible" transition:slide|local={{ duration: 300 }}>
+      <div class="mt-1 inline-flex flex-row gap-2 break-words w-full overflow-visible" transition:slide|local={{ duration: 300 }}>
         {#if $showProfileIcons}
           <img
             class="h-5 w-5 inline align-middle rounded-full flex-none"

--- a/src/components/RedirectBanner.svelte
+++ b/src/components/RedirectBanner.svelte
@@ -52,7 +52,7 @@
             {/if}
           </Icon>
         </span>
-        <span class="align-middle">Redirect Notice</span>
+        <span class="align-middle">Live Redirect Notice</span>
       </div>
       <div class="flex-none self-end" style="transform: translateY(3px);">
         <Tooltip offsetY={0} small>
@@ -78,9 +78,9 @@
         {/if}
         <MessageRun runs={redirect.item.message} forceDark forceTLColor={Theme.DARK}/>
       </div>
-      <div class="mt-1 whitespace-pre-line" transition:slide|local={{ duration: 300 }}>
+      <div class="mt-1 whitespace-pre-line flex justify-end" transition:slide|local={{ duration: 300 }}>
         <Button href={redirect.item.action.url} target="_blank" small>
-          <MessageRun runs={redirect.item.action.text} forceDark forceTLColor={Theme.DARK}/>
+          <MessageRun runs={redirect.item.action.text} forceDark forceTLColor={Theme.DARK} class="cursor-pointer" />
         </Button>
       </div>
     {/if}

--- a/src/ts/chat-utils.ts
+++ b/src/ts/chat-utils.ts
@@ -42,7 +42,7 @@ export const isValidFrameInfo = (f: Chat.UncheckedFrameInfo, port?: Chat.Port): 
   return check;
 };
 
-const actionTypes = new Set(['messages', 'bonk', 'delete', 'pin', 'unpin', 'summary', 'playerProgress', 'forceUpdate']);
+const actionTypes = new Set(['messages', 'bonk', 'delete', 'pin', 'unpin', 'summary', 'redirect', 'playerProgress', 'forceUpdate']);
 export const responseIsAction = (r: Chat.BackgroundResponse): r is Chat.Actions =>
   actionTypes.has(r.type);
 

--- a/src/ts/typings/ytc.d.ts
+++ b/src/ts/typings/ytc.d.ts
@@ -145,16 +145,14 @@ declare namespace Ytc {
   }
 
   interface ThumbnailsWithLabel extends Thumbnails {
-    accessibility?: {
-      accessibilityData: {
-        label: string;
-      };
-    };
+    accessibility?: AccessibilityObj;
   }
 
   /** Message run object */
   interface MessageRun {
     text?: string;
+    bold?: boolean;
+    deemphasize?: boolean;
     navigationEndpoint?: {
       commandMetadata: {
         webCommandMetadata: {
@@ -185,11 +183,7 @@ declare namespace Ytc {
         /** Unlocalized string */
         iconType: string;
       };
-      accessibility?: {
-        accessibilityData: {
-          label: string;
-        };
-      };
+      accessibility?: AccessibilityObj;
     };
   }
 
@@ -248,6 +242,35 @@ declare namespace Ytc {
     };
   }
 
+  interface RedirectRenderer {
+    bannerMessage: RunsObj;
+    authorPhoto?: Thumbnails;
+    inlineActionButton?: {
+      buttonRenderer: ButtonRenderer;
+    }
+    contextMenuButton?: {
+      buttonRenderer: ButtonRenderer;
+    }
+  }
+
+  interface ButtonRenderer {
+    style?: string;
+    size?: string;
+    icon?: string;
+    accessibility?: AccessibilityObj;
+    isDisabled?: boolean;
+    text?: RunsObj;
+    command: {
+      urlEndpoint?: {
+        url: string;
+        target: string;
+      }
+      watchEndpoint?: {
+        videoId: string;
+      }
+    }
+  }
+
   interface PlaceholderRenderer { // No idea what the purpose of this is
     id: string;
     timestampUsec: IntString;
@@ -271,6 +294,8 @@ declare namespace Ytc {
     liveChatSponsorshipsGiftRedemptionAnnouncementRenderer?: TextMessageRenderer;
     /** AI Chat Summary */
     liveChatBannerChatSummaryRenderer?: ChatSummaryRenderer;
+    /** Redirects */
+    liveChatBannerRedirectRenderer?: RedirectRenderer;
     /** ??? */
     liveChatPlaceholderItemRenderer?: PlaceholderRenderer;
   }
@@ -299,6 +324,12 @@ declare namespace Ytc {
     runs: MessageRun[];
   }
 
+  interface AccessibilityObj {
+    accessibilityData: {
+      label: string;
+    }
+  }
+
   /*
    * Parsed objects
    */
@@ -310,6 +341,7 @@ declare namespace Ytc {
   interface ParsedTextRun {
     type: 'text';
     text: string;
+    styles?: string[];
   }
 
   interface ParsedLinkRun {
@@ -400,13 +432,26 @@ declare namespace Ytc {
     showtime: number;
   }
 
+  interface ParsedRedirect {
+    type: 'redirect';
+    item: {
+      message: ParsedRun[];
+      profileIcon: ParsedImage;
+      action: {
+        url: string;
+        text: ParsedRun[];
+      }
+    };
+    showtime: number;
+  }
+
   interface ParsedTicker extends ParsedMessage {
     type: 'ticker';
     tickerDuration: number;
     detailText?: string;
   }
 
-  type ParsedMisc = ParsedPinned | ParsedSummary | { type: 'unpin' };
+  type ParsedMisc = ParsedPinned | ParsedSummary | ParsedRedirect | { type: 'unpin' };
 
   type ParsedTimedItem = ParsedMessage | ParsedTicker;
 


### PR DESCRIPTION
Supports send and receive, uses the urlEndpoint or watchEndpoint link to open a new tab with the given url if the button is clicked
This also adds support for bold text (but not deemphasized text yet) to MessageRun
This does not implement contextMenuButton at all yet, only inlineActionButton.
Has the same auto-collapse behavior as other banner messages.

Built on top of #156 

Very hacky URL handling and button handling at the moment.
"Redirect Notice" is added to the header because it looks a bit silly without anything there.
"Redirect profile photo" is set as the alt text for the image since the author's actual name is only available elsewhere and it would be too hacky to try to grab it.

Tested on mv3 w/ chrome

<img width="337" alt="Screenshot 2024-12-23 at 3 11 25 AM" src="https://github.com/user-attachments/assets/a6470855-32a6-4299-b31e-db8cd5a0395c" />
<img width="331" alt="Screenshot 2024-12-23 at 3 11 03 AM" src="https://github.com/user-attachments/assets/8635118d-c600-45e3-8765-7612108c49a1" />
<img width="858" alt="Screenshot 2024-12-25 at 6 54 14 PM" src="https://github.com/user-attachments/assets/9eab20eb-f6d3-4dbe-96c1-407d59a32f71" />
