### PR TITLE
Add auto-collapse capability to pinned messages based on timeout provided by bannerProperties

### DIFF
--- a/src/components/ChatSummary.svelte
+++ b/src/components/ChatSummary.svelte
@@ -20,7 +20,7 @@
       clearTimeout(autoHideTimeout);
       autoHideTimeout = null;
     }
-   };
+  };
 
   $: if (summary) {
     dismissed = false;

--- a/src/components/PinnedMessage.svelte
+++ b/src/components/PinnedMessage.svelte
@@ -10,14 +10,24 @@
 
   let dismissed = false;
   let shorten = false;
+  let autoHideTimeout: NodeJS.Timeout | null = null;
   const classes = 'rounded inline-flex flex-col overflow-visible ' +
    'bg-secondary-900 p-2 w-full text-white z-10 shadow';
 
-  const onShorten = () => { shorten = !shorten; };
-
+  const onShorten = () => { 
+    shorten = !shorten;
+    if (autoHideTimeout) {
+      clearTimeout(autoHideTimeout);
+      autoHideTimeout = null;
+    }
+  };
+  
   $: if (pinned) {
     dismissed = false;
     shorten = false;
+    if (pinned.showtime) {
+      autoHideTimeout = setTimeout(() => { shorten = true; }, pinned.showtime);
+    }
   }
 
   const dispatch = createEventDispatcher();

--- a/src/ts/chat-utils.ts
+++ b/src/ts/chat-utils.ts
@@ -42,7 +42,7 @@ export const isValidFrameInfo = (f: Chat.UncheckedFrameInfo, port?: Chat.Port): 
   return check;
 };
 
-const actionTypes = new Set(['messages', 'bonk', 'delete', 'pin', 'unpin', 'playerProgress', 'forceUpdate']);
+const actionTypes = new Set(['messages', 'bonk', 'delete', 'pin', 'unpin', 'summary', 'playerProgress', 'forceUpdate']);
 export const responseIsAction = (r: Chat.BackgroundResponse): r is Chat.Actions =>
   actionTypes.has(r.type);
 

--- a/src/ts/typings/ytc.d.ts
+++ b/src/ts/typings/ytc.d.ts
@@ -86,11 +86,19 @@ declare namespace Ytc {
             text: RunsObj;
           };
         };
+        /** Gets used for pinned messages */
+        bannerProperties?: BannerPropertiesObj;
       };
     };
-    bannerProperties?: {
-      isEphemeral: boolean;
-      bannerTimeoutMs: number;
+    /** Gets used for chat summary/redirects */
+    bannerProperties?: BannerPropertiesObj;
+  }
+
+  interface BannerPropertiesObj {
+    isEphemeral?: boolean;
+    bannerTimeoutMs?: number;
+    autoCollapseDelay?: {
+      seconds: number;
     }
   }
 
@@ -378,6 +386,7 @@ declare namespace Ytc {
       header: ParsedRun[];
       contents: ParsedMessage;
     };
+    showtime: number;
   }
 
   interface ParsedSummary {


### PR DESCRIPTION
This also updates the impl in ChatSummary, and adds a fix for responseIsAction for summary (in case YT ever starts sending summary in liveChatContinuation instead of initial data).
Note that in all cases, the behavior is auto-collapse instead of YT's default behavior of removing certain banners entirely after the time expires.

bannerProperties exists both on the top-level object as well as inside the liveChatBannerRenderer.
This impl does the following:
- Get top-level isEphemeral.
- If true, use top-level bannerTimeoutMs, or 0 if not present, and return.
- If false, use top-level autoCollapseDelay, or liveChatBannerRenderer autoCollapseDelay if not present, or 0 if also not present, and return.

In stock YT, Redirects and AI Chat Summary use the top-level properties with isEphemeral=true and bannerTimeoutMs, and pinned chat messages use the inner object with just autoCollapseDelay.
AI Chat Summary also has an inner object with isEphemeral=true and autoCollapseDelay, but it never seems to get used by stock YT, and has a 30-second value instead of the 12 seconds of the top-level properties (the actual behavior uses 12 seconds).

Tested on mv3/chrome