### PR TITLE
Remove z-index override for yt-live-chat-renderer entirely

### DIFF
--- a/src/components/HyperchatButton.svelte
+++ b/src/components/HyperchatButton.svelte
@@ -64,10 +64,6 @@
 </div>
 
 <style>
-  :global(div#contents.style-scope.yt-live-chat-renderer) {
-    z-index: 2;
-  }
-
   #hc-buttons {
     float: right;
     display: flex;


### PR DESCRIPTION
This override breaks any dialogue that shows up over chat (ending Q&As, etc), and doesn't actually appear to be used for any Hyperchat feature.