### PR TITLE
Produce MV2 build for Firefox instead

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -42,6 +42,7 @@ module.exports = {
     '@typescript-eslint/no-confusing-void-expression': 'off',
     '@typescript-eslint/no-floating-promises': 'off',
     '@typescript-eslint/no-non-null-assertion': 'off',
+    '@typescript-eslint/no-unsafe-argument': 'off',
     '@typescript-eslint/no-unused-expressions': 'off',
 
     'linebreak-style': [

--- a/README.md
+++ b/README.md
@@ -19,12 +19,6 @@ See https://livetl.app/hyperchat/install
 
 ## Building from Source
 
-### ⚠️ WARNING ⚠️
-
-For legacy reasons, we have a `mv2` branch for Firefox support while the `main` branch houses the main MV3 version.
-
-TODO: we need to confirm whether the MV2 variant is still required for modern versions of Firefox.
-
 ### Development
 
 > Note: The repo expects a Linux or Unix-like environment. If you are on Windows, use WSL.

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,5 +1,6 @@
 {
-  "manifest_version": 3,
+  "{{chrome}}.manifest_version": 3,
+  "{{firefox}}.manifest_version": 2,
   "name": "HyperChat [Improved YouTube Chat]",
   "version": "0.0.0",
   "homepage_url": "https://livetl.app/hyperchat",
@@ -11,7 +12,7 @@
   "permissions": [
     "storage"
   ],
-  "host_permissions": [
+  "{{chrome}}.host_permissions": [
     "https://www.youtube.com/live_chat*",
     "https://www.youtube.com/live_chat_replay*",
     "https://studio.youtube.com/live_chat*",
@@ -25,8 +26,11 @@
         "https://studio.youtube.com/live_chat*",
         "https://studio.youtube.com/live_chat_replay*"
       ],
-      "js": [
+      "{{chrome}}.js": [
         "scripts/chat-injector.ts"
+      ],
+      "{{firefox}}.js": [
+        "scripts/mv2/chat-injector.ts"
       ],
       "css": [
         "stylesheets/titlebar.css"
@@ -47,24 +51,35 @@
       "all_frames": true
     }
   ],
-  "{{firefox}}.background": {
-    "scripts": ["scripts/chat-background.ts"]
-  },
   "{{chrome}}.background": {
     "service_worker": "scripts/chat-background.ts"
   },
-  "action": {
+  "{{firefox}}.background": {
+    "scripts": ["scripts/mv2/chat-background.ts"],
+    "persistent": true
+  },
+  "{{chrome}}.action": {
     "default_icon": {
       "48": "assets/logo-48.png",
       "128": "assets/logo-128.png"
     },
     "default_popup": "options.html"
   },
-  "web_accessible_resources": [
+  "{{firefox}}.browser_action": {
+    "default_icon": {
+      "48": "assets/logo-48.png",
+      "128": "assets/logo-128.png"
+    },
+    "default_popup": "options.html"
+  },
+  "{{chrome}}.web_accessible_resources": [
     {
       "resources": ["*"],
       "matches": ["<all_urls>"]
     }
+  ],
+  "{{firefox}}.web_accessible_resources": [
+    "*"
   ],
   "options_ui": {
     "page": "options.html",

--- a/src/scripts/mv2/chat-background.ts
+++ b/src/scripts/mv2/chat-background.ts
@@ -1,0 +1,449 @@
+import type { Unsubscriber } from '../../ts/queue';
+import { ytcQueue } from '../../ts/queue';
+import { isValidFrameInfo } from '../../ts/chat-utils';
+import { isLiveTL } from '../../ts/chat-constants';
+import type { Chat } from '../../ts/typings/chat';
+
+const interceptors: Chat.Interceptors[] = [];
+
+const isYtcInterceptor = (i: Chat.Interceptors): i is Chat.YtcInterceptor =>
+  i.source === 'ytc';
+
+const getPortFrameInfo = (port: Chat.Port): Chat.UncheckedFrameInfo => {
+  return {
+    tabId: port.sender?.tab?.id,
+    frameId: port.sender?.frameId
+  };
+};
+
+/**
+ * Returns true if both FrameInfos are the same frame.
+ */
+const compareFrameInfo = (a: Chat.FrameInfo, b: Chat.FrameInfo): boolean => {
+  return a.tabId === b.tabId && a.frameId === b.frameId;
+};
+
+/**
+ * Returns the index of the interceptor with a matching FrameInfo.
+ * Will return `-1` if no interceptor is found.
+ */
+const findInterceptorIndex = (frameInfo: Chat.FrameInfo): number => {
+  return interceptors.findIndex(
+    (i) => compareFrameInfo(i.frameInfo, frameInfo)
+  );
+};
+
+/**
+ * Finds and returns the interceptor with a matching FrameInfo.
+ * Will return `undefined` if no interceptor is found.
+ */
+const findInterceptor = (frameInfo: Chat.FrameInfo, debugObject?: unknown): Chat.Interceptor | undefined => {
+  const i = findInterceptorIndex(frameInfo);
+  if (i < 0) {
+    console.error('Interceptor not registered', debugObject);
+    return;
+  }
+  return interceptors[i];
+};
+
+/**
+ * Finds and returns the interceptor based on the given Port.
+ * Should only be used for messages that are expected from interceptors.
+ * Will return `undefined` if no interceptor is found.
+ */
+const findInterceptorFromPort = (
+  port: Chat.Port,
+  errorObject?: Record<string, unknown>
+): Chat.Interceptor | undefined => {
+  const frameInfo = getPortFrameInfo(port);
+  if (!isValidFrameInfo(frameInfo, port)) return;
+  return findInterceptor(
+    frameInfo,
+    { interceptors, port, ...errorObject }
+  );
+};
+
+const findInterceptorFromClient = (
+  client: Chat.Port
+): Chat.Interceptor | undefined => {
+  return interceptors.find((interceptor) => {
+    for (const c of interceptor.clients) {
+      if (c.name === client.name) return true;
+    }
+    return false;
+  });
+};
+
+/**
+ * If both port and clients are empty, removes interceptor from array.
+ * Also runs the queue unsubscribe function.
+ */
+const cleanupInterceptor = (i: number): void => {
+  const interceptor = interceptors[i];
+  if (!interceptor.port && interceptor.clients.length < 1) {
+    console.debug('Removing empty interceptor', { interceptor, interceptors });
+    if (isYtcInterceptor(interceptor)) {
+      interceptor.queue.cleanUp();
+      interceptor.queueUnsub?.();
+    }
+    interceptors.splice(i, 1);
+  }
+};
+
+/**
+ * Register an interceptor into the `interceptors` array.
+ * If an interceptor with the same FrameInfo already exists, its port will be
+ * replaced with the given port instead.
+ */
+const registerInterceptor = (
+  port: Chat.Port,
+  source: Chat.InterceptorSource,
+  isReplay?: boolean
+): void => {
+  const frameInfo = getPortFrameInfo(port);
+  if (!isValidFrameInfo(frameInfo, port)) return;
+
+  // Unregister interceptor when port disconnects
+  port.onDisconnect.addListener(() => {
+    const i = findInterceptorIndex(frameInfo);
+    if (i < 0) {
+      console.error(
+        'Failed to unregister interceptor',
+        { port, interceptors }
+      );
+      return;
+    }
+    interceptors[i].port = undefined;
+    cleanupInterceptor(i);
+    console.debug('Interceptor unregistered', { port, interceptors });
+  });
+
+  // Replace port if interceptor already exists
+  const i = findInterceptorIndex(frameInfo);
+  if (i >= 0) {
+    console.debug(
+      'Replacing existing interceptor port',
+      { oldPort: interceptors[i].port, port }
+    );
+    interceptors[i].port = port;
+    return;
+  }
+
+  // Add interceptor to array
+  const interceptor = {
+    frameInfo,
+    port,
+    clients: []
+  };
+  if (source === 'ytc') {
+    const queue = ytcQueue(isReplay);
+    let queueUnsub: Unsubscriber | undefined;
+    const ytcInterceptor: Chat.YtcInterceptor = {
+      ...interceptor,
+      source: 'ytc',
+      dark: false,
+      queue,
+      queueUnsub
+    };
+    interceptors.push(ytcInterceptor);
+    ytcInterceptor.queueUnsub = queue.latestAction.subscribe((latestAction) => {
+      const interceptor = findInterceptorFromPort(port, { latestAction });
+      if (!interceptor || !latestAction) return;
+      interceptor.clients.forEach((port) => port.postMessage(latestAction));
+    });
+  } else {
+    interceptors.push({ ...interceptor, source });
+  }
+  console.debug('New interceptor registered', { port, interceptors });
+};
+
+/**
+ * Register a client to the interceptor with the matching FrameInfo.
+ */
+const registerClient = (
+  port: Chat.Port,
+  frameInfo: Chat.FrameInfo,
+  getInitialData = false
+): void => {
+  const interceptor = findInterceptor(
+    frameInfo,
+    { interceptors, port, frameInfo }
+  );
+  if (!interceptor) {
+    port.postMessage(
+      {
+        type: 'registerClientResponse',
+        success: false,
+        failReason: 'Interceptor not found'
+      }
+    );
+    return;
+  }
+
+  if (interceptor.clients.some((client) => client.name === port.name)) {
+    console.debug(
+      'Client already registered. Not registering',
+      { interceptors, port, frameInfo }
+    );
+    port.postMessage(
+      {
+        type: 'registerClientResponse',
+        success: false,
+        failReason: 'Client already registered'
+      }
+    );
+    return;
+  }
+
+  // Assign pseudo-unique name
+  port.name = `${Date.now()}${Math.random()}`;
+
+  // Unregister client when port disconnects
+  port.onDisconnect.addListener(() => {
+    const i = interceptor.clients.findIndex(
+      (clientPort) => clientPort.name === port.name
+    );
+    if (i < 0) {
+      console.error('Failed to unregister client', { port, interceptor });
+      return;
+    }
+    interceptor.clients.splice(i, 1);
+    console.debug('Unregister client successful', { port, interceptor });
+
+    cleanupInterceptor(findInterceptorIndex(frameInfo));
+  });
+
+  // Add client to array
+  interceptor.clients.push(port);
+  console.debug('Register client successful', { port, interceptor });
+  port.postMessage(
+    {
+      type: 'registerClientResponse',
+      success: true
+    }
+  );
+
+  if (getInitialData && isYtcInterceptor(interceptor)) {
+    const selfChannel = interceptor.queue.selfChannel.get();
+    const payload: Chat.InitialData = {
+      type: 'initialData',
+      initialData: interceptor.queue.getInitialData(),
+      selfChannel: selfChannel != null
+        ? {
+            name: selfChannel.authorName?.simpleText ?? '',
+            channelId: selfChannel.authorExternalChannelId ?? ''
+          }
+        : null
+    };
+    port.postMessage(payload);
+    console.debug('Sent initial data', { port, interceptor, payload });
+  }
+};
+
+/**
+ * Parses the given YTC json response, and adds it to the queue of the
+ * interceptor that sent it.
+ */
+const processMessageChunk = (port: Chat.Port, message: Chat.JsonMsg): void => {
+  const json = message.json;
+  const interceptor = findInterceptorFromPort(port, { message });
+  if (!interceptor || !isYtcInterceptor(interceptor)) return;
+
+  if (interceptor.clients.length < 1) {
+    console.debug('No clients', { interceptor, json });
+    return;
+  }
+
+  interceptor.queue.addJsonToQueue(json, false, interceptor);
+};
+
+/**
+ * Parses a sent message and adds a fake message entry.
+ */
+const processSentMessage = (port: Chat.Port, message: Chat.JsonMsg): void => {
+  const json = message.json;
+  const interceptor = findInterceptorFromPort(port, { message });
+  if (!interceptor || !isYtcInterceptor(interceptor)) return;
+
+  const fakeJson: Ytc.SentChatItemAction = JSON.parse(json);
+  const fakeChunk: Ytc.RawResponse = {
+    continuationContents: {
+      liveChatContinuation: {
+        continuations: [{
+          timedContinuationData: {
+            timeoutMs: 0
+          }
+        }],
+        actions: fakeJson.actions
+      }
+    }
+  };
+  interceptor.queue.addJsonToQueue(JSON.stringify(
+    fakeChunk
+  ), false, interceptor, true);
+};
+
+/**
+ * Parses and sets initial message data and metadata.
+ */
+const setInitialData = (port: Chat.Port, message: Chat.JsonMsg): void => {
+  const json = message.json;
+  const interceptor = findInterceptorFromPort(port, { message });
+  if (!interceptor || !isYtcInterceptor(interceptor)) return;
+
+  interceptor.queue.addJsonToQueue(json, true, interceptor);
+
+  const parsedJson = JSON.parse(json);
+
+  const actionPanel = (parsedJson?.continuationContents?.liveChatContinuation ||
+    parsedJson?.contents?.liveChatRenderer)
+    ?.actionPanel;
+
+  const user = actionPanel?.liveChatMessageInputRenderer
+    ?.sendButton?.buttonRenderer?.serviceEndpoint
+    ?.sendLiveChatMessageEndpoint?.actions[0]
+    ?.addLiveChatTextMessageFromTemplateAction?.template
+    ?.liveChatTextMessageRenderer ?? {
+    authorName: {
+      simpleText: parsedJson?.continuationContents?.liveChatContinuation?.viewerName
+    }
+  };
+
+  interceptor.queue.selfChannel.set(user);
+};
+
+/**
+ * Updates the player progress of the queue of the interceptor.
+ */
+const updatePlayerProgress = (port: Chat.Port, playerProgress: number, isFromYt?: boolean): void => {
+  const interceptor = findInterceptorFromPort(port, { playerProgress });
+  if (!interceptor) return;
+
+  // yt needs logic for clearing chat messages and forcing updates
+  // yt's updatePlayerProgress will send the playerProgress message in the method
+  if (isYtcInterceptor(interceptor)) {
+    interceptor.queue.updatePlayerProgress(playerProgress, isFromYt);
+  } else { // send to all twitch clients
+    interceptor.clients.forEach(port => port.postMessage({ type: 'playerProgress', playerProgress }));
+  }
+};
+
+/**
+ * Sets the theme of the interceptor, and sends the new theme to any currently
+ * registered clients.
+ */
+const setTheme = (port: Chat.Port, dark: boolean): void => {
+  const interceptor = findInterceptorFromPort(port, { dark });
+  if (!interceptor || !isYtcInterceptor(interceptor)) return;
+
+  interceptor.dark = dark;
+  interceptor.clients.forEach(
+    (port) => port.postMessage({ type: 'themeUpdate', dark })
+  );
+  console.debug(`Set dark theme to ${dark.toString()}`);
+};
+
+/**
+ * Returns a message with the theme of the interceptor with a matching
+ * FrameInfo.
+ */
+const getTheme = (port: Chat.Port, frameInfo: Chat.FrameInfo): void => {
+  const interceptor = findInterceptor(
+    frameInfo,
+    { interceptors, port, frameInfo }
+  );
+  if (!interceptor || !isYtcInterceptor(interceptor)) return;
+
+  port.postMessage({ type: 'themeUpdate', dark: interceptor.dark });
+};
+
+const sendLtlMessage = (port: Chat.Port, message: Chat.LtlMessage): void => {
+  const interceptor = findInterceptorFromPort(port, { message });
+  if (!interceptor) return;
+
+  interceptor.clients.forEach(
+    (clientPort) => clientPort.postMessage({ type: 'ltlMessage', message })
+  );
+};
+
+const executeChatAction = (
+  port: Chat.Port,
+  message: Chat.executeChatActionMsg
+): void => {
+  const interceptor = findInterceptorFromClient(port);
+  interceptor?.port?.postMessage(message);
+};
+
+const sendChatUserActionResponse = (
+  port: Chat.Port,
+  message: Chat.chatUserActionResponse
+): void => {
+  const interceptor = findInterceptorFromPort(port, { message });
+  if (!interceptor) return;
+
+  interceptor.clients.forEach(
+    (clientPort) => clientPort.postMessage(message)
+  );
+};
+
+chrome.runtime.onConnect.addListener((port) => {
+  port.onMessage.addListener((message: Chat.BackgroundMessage) => {
+    switch (message.type) {
+      case 'registerInterceptor':
+        registerInterceptor(port, message.source, message.isReplay);
+        break;
+      case 'registerClient':
+        registerClient(port, message.frameInfo, message.getInitialData);
+        break;
+      case 'processMessageChunk':
+        processMessageChunk(port, message);
+        break;
+      case 'processSentMessage':
+        processSentMessage(port, message);
+        break;
+      case 'setInitialData':
+        setInitialData(port, message);
+        break;
+      case 'updatePlayerProgress':
+        updatePlayerProgress(port, message.playerProgress, message.isFromYt);
+        break;
+      case 'setTheme':
+        setTheme(port, message.dark);
+        break;
+      case 'getTheme':
+        getTheme(port, message.frameInfo);
+        break;
+      case 'sendLtlMessage':
+        sendLtlMessage(port, message.message);
+        break;
+      case 'executeChatAction':
+        executeChatAction(port, message);
+        break;
+      case 'chatUserActionResponse':
+        sendChatUserActionResponse(port, message);
+        break;
+      default:
+        console.error('Unknown message type', port, message);
+        break;
+    }
+  });
+});
+
+chrome.browserAction.onClicked.addListener(() => {
+  if (isLiveTL) {
+    chrome.tabs.create({ url: 'https://livetl.app' }, () => {});
+  } else {
+    chrome.tabs.create({ url: 'https://livetl.app/hyperchat' }, () => {});
+  }
+});
+
+chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
+  if (request.type === 'getFrameInfo') {
+    sendResponse({ tabId: sender.tab?.id, frameId: sender.frameId });
+  } else if (request.type === 'createPopup') {
+    chrome.windows.create({
+      url: request.url,
+      type: 'popup'
+    }, () => {});
+  }
+});

--- a/src/scripts/mv2/chat-injector.ts
+++ b/src/scripts/mv2/chat-injector.ts
@@ -1,0 +1,78 @@
+import HcButton from '../../components/HyperchatButton.svelte';
+import { getFrameInfoAsync, isValidFrameInfo, frameIsReplay, checkInjected } from '../../ts/chat-utils';
+import { isLiveTL } from '../../ts/chat-constants';
+import { hcEnabled, autoLiveChat } from '../../ts/storage';
+
+const hcWarning = 'An existing HyperChat button has been detected. This ' +
+  'usually means both LiveTL and standalone HyperChat are enabled. ' +
+  'LiveTL already includes HyperChat, so please enable only one of them.\n\n' +
+  'Having multiple instances of the same scripts running WILL cause ' +
+  'problems such as chat messages not loading.';
+
+const chatLoaded = async (): Promise<void> => {
+  if (!isLiveTL && checkInjected(hcWarning)) return;
+
+  document.body.style.minWidth = document.body.style.minHeight = '0px';
+  const hyperChatEnabled = await hcEnabled.get();
+
+  // Inject HC button
+  const ytcPrimaryContent = document.querySelector('#primary-content');
+  if (!ytcPrimaryContent) {
+    console.error('Failed to find #primary-content');
+    return;
+  }
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const hcButton = new HcButton({
+    target: ytcPrimaryContent
+  });
+
+  // Everything past this point will only run if HC is enabled
+  if (!hyperChatEnabled) return;
+
+  const ytcItemList = document.querySelector('#chat>#item-list');
+  if (!ytcItemList) {
+    console.error('Failed to find #chat>#item-list');
+    return;
+  }
+
+  // Inject hyperchat
+  const frameInfo = await getFrameInfoAsync();
+  if (!isValidFrameInfo(frameInfo)) {
+    console.error('Failed to get valid frame info', { frameInfo });
+    return;
+  }
+  const params = new URLSearchParams();
+  params.set('tabid', frameInfo.tabId.toString());
+  params.set('frameid', frameInfo.frameId.toString());
+  if (frameIsReplay()) params.set('isReplay', 'true');
+  const source = chrome.runtime.getURL(
+    (isLiveTL ? 'hyperchat/index.html' : 'hyperchat.html') +
+    `?${params.toString()}`
+  );
+  ytcItemList.outerHTML = `<iframe id="hyperchat" src="${source}" style="border: 0px; width: 100%; height: 100%;"/>`;
+
+  // Remove ticker element
+  const ytcTicker = document.querySelector('#ticker');
+  if (!ytcTicker) {
+    console.error('Failed to find #ticker');
+    return;
+  }
+  ytcTicker.remove();
+
+  if (await autoLiveChat.get()) {
+    const live = document.querySelector<HTMLElement>('tp-yt-paper-listbox#menu > :nth-child(2)');
+    if (!live) {
+      console.error('Failed to find Live Chat menu item');
+      return;
+    }
+    live.click();
+  }
+};
+
+if (isLiveTL) {
+  chatLoaded().catch(console.error);
+} else {
+  setTimeout(() => {
+    chatLoaded().catch(console.error);
+  }, 500);
+}

--- a/src/scripts/mv2/chat-interceptor.ts
+++ b/src/scripts/mv2/chat-interceptor.ts
@@ -1,0 +1,255 @@
+import sha1 from 'sha-1';
+
+import { fixLeaks } from '../../ts/ytc-fix-memleaks';
+import { frameIsReplay as isReplay, checkInjected } from '../../ts/chat-utils';
+import { chatReportUserOptions, ChatUserActions, isLiveTL } from '../../ts/chat-constants';
+import type { Chat } from '../../ts/typings/chat';
+
+function injectedFunction(): void {
+  const currentDomain = (location.protocol + '//' + location.host);
+  for (const eventName of ['visibilitychange', 'webkitvisibilitychange', 'blur']) {
+    window.addEventListener(eventName, event => {
+      event.stopImmediatePropagation();
+    }, true);
+  }
+  const fetchFallback = window.fetch;
+  (window as any).fetchFallback = fetchFallback;
+  window.fetch = async (...args) => {
+    const request = args[0] as Request;
+    const url = request.url;
+    const result = await fetchFallback(...args);
+
+    const ytApi = (end: string): string => `${currentDomain}/youtubei/v1/live_chat${end}`;
+    const isReceiving = url.startsWith(ytApi('/get_live_chat'));
+    const isSending = url.startsWith(ytApi('/send_message'));
+    const action = isReceiving ? 'messageReceive' : 'messageSent';
+    if (isReceiving || isSending) {
+      const response = JSON.stringify(await (result.clone()).json());
+      window.dispatchEvent(new CustomEvent(action, { detail: response }));
+    }
+    return result;
+  };
+  window.dispatchEvent(new CustomEvent('chatLoaded', {
+    detail: JSON.stringify(window.ytcfg)
+  }));
+  // eslint-disable-next-line @typescript-eslint/no-misused-promises
+  window.addEventListener('proxyFetchRequest', async (event) => {
+    const args = JSON.parse((event as any).detail as string) as [string, any];
+    const request = await fetchFallback(...args);
+    const response = await request.json();
+    window.dispatchEvent(new CustomEvent('proxyFetchResponse', {
+      detail: JSON.stringify(response)
+    }));
+  });
+}
+
+const chatLoaded = async (): Promise<void> => {
+  const warning = 'HC button detected, not injecting interceptor.';
+  if (!isLiveTL && checkInjected(warning)) return;
+
+  // Register interceptor
+  const port: Chat.Port = chrome.runtime.connect();
+  port.postMessage({ type: 'registerInterceptor', source: 'ytc', isReplay: isReplay() });
+
+  // Send JSON response to clients
+  window.addEventListener('messageReceive', (d) => {
+    port.postMessage({
+      type: 'processMessageChunk',
+      json: (d as CustomEvent).detail
+    });
+  });
+
+  window.addEventListener('messageSent', (d) => {
+    port.postMessage({
+      type: 'processSentMessage',
+      json: (d as CustomEvent).detail
+    });
+  });
+
+  window.addEventListener('chatLoaded', (d) => {
+    const ytcfg = (JSON.parse((d as CustomEvent).detail) as {
+      data_: {
+        INNERTUBE_API_KEY: string;
+        INNERTUBE_CONTEXT: any;
+      };
+    });
+    const fetcher = async (...args: any[]): Promise<any> => {
+      return await new Promise((resolve) => {
+        const encoded = JSON.stringify(args);
+        window.addEventListener('proxyFetchResponse', (e) => {
+          const response = JSON.parse((e as CustomEvent).detail);
+          resolve(response);
+        });
+        window.dispatchEvent(new CustomEvent('proxyFetchRequest', {
+          detail: encoded
+        }));
+      });
+    };
+
+    // eslint-disable-next-line @typescript-eslint/no-misused-promises
+    port.onMessage.addListener(async (msg) => {
+      if (msg.type !== 'executeChatAction') return;
+      const message = msg.message;
+      if (message.params == null) return;
+      let success = true;
+      try {
+        const currentDomain = (location.protocol + '//' + location.host);
+        // const action = msg.action;
+        const apiKey = ytcfg.data_.INNERTUBE_API_KEY;
+        const contextMenuUrl = `${currentDomain}/youtubei/v1/live_chat/get_item_context_menu?params=` +
+          `${encodeURIComponent(message.params)}&pbj=1&key=${apiKey}&prettyPrint=false`;
+        const baseContext = ytcfg.data_.INNERTUBE_CONTEXT;
+        function getCookie(name: string): string {
+          const value = `; ${document.cookie}`;
+          const parts = value.split(`; ${name}=`);
+          if (parts.length === 2) return (parts.pop() ?? '').split(';').shift() ?? '';
+          return '';
+        }
+        const time = Math.floor(Date.now() / 1000);
+        const SAPISID = getCookie('__Secure-3PAPISID');
+        const sha = sha1(`${time} ${SAPISID} ${currentDomain}`);
+        const auth = `SAPISIDHASH ${time}_${sha}`;
+        const heads = {
+          headers: {
+            'Content-Type': 'application/json',
+            Accept: '*/*',
+            Authorization: auth
+          },
+          method: 'POST'
+        };
+        const res = await fetcher(contextMenuUrl, {
+          ...heads,
+          body: JSON.stringify({ context: baseContext })
+        });
+        function parseServiceEndpoint(serviceEndpoint: any, prop: string): { params: string, context: any } {
+          const { clickTrackingParams, [prop]: { params } } = serviceEndpoint;
+          const clonedContext = JSON.parse(JSON.stringify(baseContext));
+          clonedContext.clickTracking = {
+            clickTrackingParams
+          };
+          return {
+            params,
+            context: clonedContext
+          };
+        }
+        if (msg.action === ChatUserActions.BLOCK) {
+          const { params, context } = parseServiceEndpoint(
+            res.liveChatItemContextMenuSupportedRenderers.menuRenderer.items[1]
+              .menuNavigationItemRenderer.navigationEndpoint.confirmDialogEndpoint
+              .content.confirmDialogRenderer.confirmButton.buttonRenderer.serviceEndpoint,
+            'moderateLiveChatEndpoint'
+          );
+          await fetcher(`${currentDomain}/youtubei/v1/live_chat/moderate?key=${apiKey}&prettyPrint=false`, {
+            ...heads,
+            body: JSON.stringify({
+              params,
+              context
+            })
+          });
+        } else if (msg.action === ChatUserActions.REPORT_USER) {
+          const { params, context } = parseServiceEndpoint(
+            res.liveChatItemContextMenuSupportedRenderers.menuRenderer.items[0].menuServiceItemRenderer.serviceEndpoint,
+            'getReportFormEndpoint'
+          );
+          const modal = await fetcher(`${currentDomain}/youtubei/v1/flag/get_form?key=${apiKey}&prettyPrint=false`, {
+            ...heads,
+            body: JSON.stringify({
+              params,
+              context
+            })
+          });
+          const index = chatReportUserOptions.findIndex(d => d.value === msg.reportOption);
+          const options = modal.actions[0].openPopupAction.popup.reportFormModalRenderer.optionsSupportedRenderers.optionsRenderer.items;
+          const submitEndpoint = options[index].optionSelectableItemRenderer.submitEndpoint;
+          const clickTrackingParams = submitEndpoint.clickTrackingParams;
+          const flagAction = submitEndpoint.flagEndpoint.flagAction;
+          context.clickTracking = {
+            clickTrackingParams
+          };
+          await fetcher(`${currentDomain}/youtubei/v1/flag/flag?key=${apiKey}&prettyPrint=false`, {
+            ...heads,
+            body: JSON.stringify({
+              action: flagAction,
+              context
+            })
+          });
+        }
+      } catch (e) {
+        console.debug('Error executing chat action', e);
+        success = false;
+      }
+      port.postMessage({
+        type: 'chatUserActionResponse',
+        action: msg.action,
+        message,
+        success
+      });
+    });
+  });
+
+  // Inject interceptor script
+  const script = document.createElement('script');
+  script.innerHTML = `(${injectedFunction.toString()})();`;
+  document.body.appendChild(script);
+
+  // Handle initial data
+  const scripts = document.querySelector('body')?.querySelectorAll('script');
+  if (!scripts) {
+    console.error('Unable to get script elements.');
+    return;
+  }
+  for (const script of Array.from(scripts)) {
+    const start = 'window["ytInitialData"] = ';
+    const text = script.text;
+    if (!text || !text.startsWith(start)) {
+      continue;
+    }
+    const json = text.replace(start, '').slice(0, -1);
+    port.postMessage({
+      type: 'setInitialData',
+      json
+    });
+    break;
+  }
+
+  // Catch YT messages
+  window.addEventListener('message', (d) => {
+    if (d.data['yt-player-video-progress'] != null) {
+      port.postMessage({
+        type: 'updatePlayerProgress',
+        playerProgress: d.data['yt-player-video-progress'],
+        isFromYt: true
+      });
+    }
+  });
+
+  // Update dark theme whenever it changes
+  let wasDark: boolean | undefined;
+  const html = document.documentElement;
+  const sendTheme = (): void => {
+    const isDark = html.hasAttribute('dark');
+    if (isDark === wasDark) return;
+    port.postMessage({
+      type: 'setTheme',
+      dark: isDark
+    });
+    wasDark = isDark;
+  };
+  new MutationObserver(sendTheme).observe(html, {
+    attributes: true
+  });
+  sendTheme();
+
+  // Inject mem leak fix script
+  const fixLeakScript = document.createElement('script');
+  fixLeakScript.innerHTML = `(${fixLeaks.toString()})();`;
+  document.body.appendChild(fixLeakScript);
+};
+
+if (isLiveTL) {
+  chatLoaded().catch(console.error);
+} else {
+  setTimeout(() => {
+    chatLoaded().catch(console.error);
+  }, 500);
+}

--- a/src/ts/typings/chat.d.ts
+++ b/src/ts/typings/chat.d.ts
@@ -161,8 +161,8 @@ declare namespace Chat {
   };
 
   interface Interceptor {
-    // frameInfo: FrameInfo;
-    // port?: Port;
+    frameInfo: FrameInfo;
+    port?: Port;
     clients: Port[];
     source?: InterceptorSource;
   }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -36,6 +36,7 @@ export default defineConfig({
       ],
       additionalInputs: [
         'hyperchat.html',
+        'scripts/mv2/chat-interceptor.ts',
         'scripts/chat-interceptor.ts',
         'scripts/chat-metagetter.ts'
       ],


### PR DESCRIPTION
Based on diffs in https://github.com/LiveTL/HyperChat/pull/163

Context from @KentoNishi / @r2dev2:

- HyperChat is actually published in its MV3 form for both Chrome and Firefox stores
- Firefox UX is lacking for prompting for runtime host permissions, where the user needs to go and grant permissions manually in the extension settings (pending improvements: https://bugzilla.mozilla.org/show_bug.cgi?id=1839129)
- The MV2 branch is actually just for use with the MV2 build of LiveTL (which is published as MV3 for Chrome and MV2 for Firefox)

Still pending relevant logic differences so it actually handles the chat part properly in Firefox.