### PR TITLE
Add implementation for showing poll results, make unpin action actionId-aware

### DIFF
--- a/src/components/Hyperchat.svelte
+++ b/src/components/Hyperchat.svelte
@@ -68,31 +68,6 @@
   let pinned: Ytc.ParsedPinned | null;
   let summary: Ytc.ParsedSummary | null;
   let redirect: Ytc.ParsedRedirect | null;
-  // = {
-  //   type: 'redirect',
-  //   item: {
-  //     message: [
-  //       {
-  //         type: 'text',
-  //         text: 'Don\'t miss out! People are going to watch something from someone',
-  //       },
-  //     ],
-  //     profileIcon: {
-  //       src: 'https://picsum.photos/32',
-  //       alt: 'Redirect profile photo',
-  //     },
-  //     action: {
-  //       url: 'https://example.com/',
-  //       text: [
-  //         {
-  //           type: 'text',
-  //           text: 'Go Now',
-  //         },
-  //       ],
-  //     },
-  //   },
-  //   showtime: 5000,
-  // };
   $: hasBanner = poll ?? pinned ?? redirect ?? (summary && $showChatSummary);
   let div: HTMLElement;
   let isAtBottom = true;

--- a/src/components/Hyperchat.svelte
+++ b/src/components/Hyperchat.svelte
@@ -8,6 +8,7 @@
   import PinnedMessage from './PinnedMessage.svelte';
   import ChatSummary from './ChatSummary.svelte';
   import RedirectBanner from './RedirectBanner.svelte';
+  import PollResults from './PollResults.svelte';
   import PaidMessage from './PaidMessage.svelte';
   import MembershipItem from './MembershipItem.svelte';
   import ReportBanDialog from './ReportBanDialog.svelte';
@@ -63,6 +64,7 @@
   const TRUNCATE_SIZE = 20;
   let messageActions: Array<Chat.MessageAction | Welcome> = [];
   const messageKeys = new Set<string>();
+  let poll: Ytc.ParsedPoll | null;
   let pinned: Ytc.ParsedPinned | null;
   let summary: Ytc.ParsedSummary | null;
   let redirect: Ytc.ParsedRedirect | null;
@@ -91,7 +93,7 @@
   //   },
   //   showtime: 5000,
   // };
-  $: hasBanner = pinned ?? redirect ?? (summary && $showChatSummary);
+  $: hasBanner = poll ?? pinned ?? redirect ?? (summary && $showChatSummary);
   let div: HTMLElement;
   let isAtBottom = true;
   let truncateInterval: number | undefined;
@@ -222,6 +224,9 @@
       case 'delete':
         onDelete(action.deletion);
         break;
+      case 'poll':
+        poll = action;
+        break;
       case 'summary':
         summary = action;
         break;
@@ -232,7 +237,22 @@
         pinned = action;
         break;
       case 'unpin':
-        pinned = null;
+        if (action.targetActionId) {
+          if (action.targetActionId === pinned?.actionId) {
+            pinned = null;
+          }
+          if (action.targetActionId === summary?.actionId) {
+            summary = null;
+          }
+          if (action.targetActionId === poll?.actionId) {
+            poll = null;
+          }
+          if (action.targetActionId === redirect?.actionId) {
+            redirect = null;
+          }
+        } else {
+          pinned = null;
+        }
         break;
       case 'playerProgress':
         $currentProgress = action.playerProgress;
@@ -401,7 +421,7 @@
       }
     }, 350);
   };
-  $: $enableStickySuperchatBar, pinned, topBarResized();
+  $: $enableStickySuperchatBar, hasBanner, topBarResized();
 
   const isMention = (msg: Ytc.ParsedMessage) => {
     return $selfChannelName && msg.message.map(run => {
@@ -457,6 +477,11 @@
     </div>
     {#if hasBanner}
       <div class="absolute top-0 w-full" bind:this={topBar}>
+        {#if poll}
+          <div class="mx-1.5 mt-1.5">
+            <PollResults poll={poll} on:resize={topBarResized} />
+          </div>
+        {/if}
         {#if summary && $showChatSummary}
           <div class="mx-1.5 mt-1.5">
             <ChatSummary summary={summary} on:resize={topBarResized} />

--- a/src/components/PollResults.svelte
+++ b/src/components/PollResults.svelte
@@ -20,7 +20,7 @@
     shorten = !shorten;
   };
   
-  $: if (poll.actionId != prevId) {
+  $: if (poll.actionId !== prevId) {
     dismissed = false;
     shorten = false;
     prevId = poll.actionId;

--- a/src/components/PollResults.svelte
+++ b/src/components/PollResults.svelte
@@ -79,9 +79,9 @@
         <MessageRun runs={poll.item.question} forceDark forceTLColor={Theme.DARK}/>
       </div>
       {#each poll.item.choices as choice}
-        <div class="mt-1 w-full whitespace-pre-line flex justify-start" transition:slide|global={{ duration: 300 }}>
+        <div class="mt-1 w-full whitespace-pre-line flex justify-start items-end" transition:slide|global={{ duration: 300 }}>
           <MessageRun runs={choice.text} forceDark forceTLColor={Theme.DARK} />
-          <span class="ml-auto align-middle" transition:slide|global={{ duration: 300 }}>
+          <span class="ml-auto" transition:slide|global={{ duration: 300 }}>
             {choice.percentage}
           </span>
         </div>

--- a/src/components/PollResults.svelte
+++ b/src/components/PollResults.svelte
@@ -26,8 +26,6 @@
     prevId = poll.actionId;
   }
 
-  $: poll;
-
   const dispatch = createEventDispatcher();
   $: dismissed, shorten, dispatch('resize');
 </script>

--- a/src/components/PollResults.svelte
+++ b/src/components/PollResults.svelte
@@ -1,0 +1,92 @@
+<script lang="ts">
+  import { slide, fade } from 'svelte/transition';
+  import MessageRun from './MessageRuns.svelte';
+  import Tooltip from './common/Tooltip.svelte';
+  import Icon from 'smelte/src/components/Icon';
+  import { Theme } from '../ts/chat-constants';
+  import { createEventDispatcher } from 'svelte';
+  import { showProfileIcons } from '../ts/storage';
+  import ProgressLinear from 'smelte/src/components/ProgressLinear';
+
+  export let poll: Ytc.ParsedPoll;
+
+  let dismissed = false;
+  let shorten = false;
+  let prevId: string | null = null;
+  const classes = 'rounded inline-flex flex-col overflow-visible ' +
+   'bg-secondary-900 p-2 w-full text-white z-10 shadow';
+
+  const onShorten = () => {
+    shorten = !shorten;
+  };
+  
+  $: if (poll.actionId != prevId) {
+    dismissed = false;
+    shorten = false;
+    prevId = poll.actionId;
+  }
+
+  $: poll;
+
+  const dispatch = createEventDispatcher();
+  $: dismissed, shorten, dispatch('resize');
+</script>
+
+{#if !dismissed}
+  <div
+    class={classes}
+    transition:fade={{ duration: 250 }}
+  >
+    <div class="flex flex-row items-center cursor-pointer" on:click={onShorten}>
+      <div class="font-medium tracking-wide text-white flex-1">
+        <span class="mr-1 inline-block" style="transform: translateY(3px);">
+          <Icon small>
+            {#if shorten}
+              expand_more
+            {:else}
+              expand_less
+            {/if}
+          </Icon>
+        </span>
+        {#if $showProfileIcons}
+          <img
+            class="h-5 w-5 inline align-middle rounded-full flex-none"
+            src={poll.item.profileIcon.src}
+            alt={poll.item.profileIcon.alt}
+          />
+        {/if}
+        {#each poll.item.header as run}
+          {#if run.type === 'text'}
+            <span class="align-middle">{run.text}</span>
+          {/if}
+        {/each}
+      </div>
+      <div class="flex-none self-end" style="transform: translateY(3px);">
+        <Tooltip offsetY={0} small>
+          <Icon
+            slot="activator"
+            class="cursor-pointer text-lg"
+            on:click={() => { dismissed = true; }}
+          >
+            close
+          </Icon>
+          Dismiss
+        </Tooltip>
+      </div>
+    </div>
+    {#if !shorten && !dismissed}
+      <div class="mt-1 inline-flex flex-row gap-2 break-words w-full overflow-visible" transition:slide|local={{ duration: 300 }}>
+        <MessageRun runs={poll.item.question} forceDark forceTLColor={Theme.DARK}/>
+      </div>
+      {#each poll.item.choices as choice}
+        <div class="mt-1 w-full whitespace-pre-line flex justify-start" transition:slide|global={{ duration: 300 }}>
+          <MessageRun runs={choice.text} forceDark forceTLColor={Theme.DARK} class="cursor-pointer" />
+          <span class="ml-auto align-middle" transition:slide|global={{ duration: 300 }}>
+            {choice.percentage}
+          </span>
+        </div>
+        <ProgressLinear progress={(choice.ratio || 0.001) * 100} color="gray"/>
+      {/each}
+    {/if}
+  </div>
+{/if}

--- a/src/components/PollResults.svelte
+++ b/src/components/PollResults.svelte
@@ -80,7 +80,7 @@
       </div>
       {#each poll.item.choices as choice}
         <div class="mt-1 w-full whitespace-pre-line flex justify-start" transition:slide|global={{ duration: 300 }}>
-          <MessageRun runs={choice.text} forceDark forceTLColor={Theme.DARK} class="cursor-pointer" />
+          <MessageRun runs={choice.text} forceDark forceTLColor={Theme.DARK} />
           <span class="ml-auto align-middle" transition:slide|global={{ duration: 300 }}>
             {choice.percentage}
           </span>

--- a/src/ts/chat-utils.ts
+++ b/src/ts/chat-utils.ts
@@ -44,7 +44,7 @@ export const isValidFrameInfo = (f: Chat.UncheckedFrameInfo, port?: Chat.Port): 
   return check;
 };
 
-const actionTypes = new Set(['messages', 'bonk', 'delete', 'pin', 'unpin', 'summary', 'redirect', 'playerProgress', 'forceUpdate']);
+const actionTypes = new Set(['messages', 'bonk', 'delete', 'pin', 'unpin', 'summary', 'poll', 'redirect', 'playerProgress', 'forceUpdate']);
 export const responseIsAction = (r: Chat.BackgroundResponse): r is Chat.Actions =>
   actionTypes.has(r.type);
 


### PR DESCRIPTION
Closes #110
Uses gray as the ProgressLinear color so that the white bar background shows up (tried all other options, it either made it completely invisible or had no background).

The actionId changes are so that multiple things can be removed via the removal message (e.g. polls) instead of only pinned messages.

Actual voting panel isn't implemented because it SEEMS like it *just works* with Hyperchat enabled already; no need to try to replace it.

![image](https://github.com/user-attachments/assets/b9b59523-b889-41a7-ba39-608577a9ad06)
![image](https://github.com/user-attachments/assets/88349d65-3fb6-4153-b8b6-8666e08031aa)
