### PR TITLE
Attempt to fix Hyperchat embed mounter showing YT controls

### DIFF
--- a/src/scripts/chat-mounter.ts
+++ b/src/scripts/chat-mounter.ts
@@ -6,6 +6,7 @@ const mount = (): void => {
   console.log('[HyperChat] mounted hyperchat as content script');
 
   document.querySelector('#player')?.remove();
+  document.querySelector('#player-controls')?.remove();
 
   document.documentElement.style.cssText = 'background-color: transparent !important;';
   document.body.style.cssText = 'background-color: transparent !important;';


### PR DESCRIPTION
_should_ fix this issue:
<img width="313" height="426" alt="Screenshot 2026-03-26 at 4 21 52 PM" src="https://github.com/user-attachments/assets/d5fed5bc-d5f0-4597-99ac-13b04a6836bf" />
