### PR TITLE
Fix TranslatedMessage leaking whitespace

### DIFF
--- a/src/components/TranslatedMessage.svelte
+++ b/src/components/TranslatedMessage.svelte
@@ -20,7 +20,8 @@
     });
   }
 
-  $: showTL = Boolean(translatedMessage && !showOriginal && translatedMessage.trim() !== text.trim());
+  $: hasTranslation = Boolean(translatedMessage && translatedMessage.trim() !== text.trim());
+  $: showTL = hasTranslation && !showOriginal;
 
   $: if ($translateTargetLanguage !== translatedLanguage) {
     translatedMessage = '';
@@ -30,34 +31,31 @@
   $: translatedColor = forceTLColor === Theme.DARK
     ? 'text-translated-dark'
     : `text-translated-light ${forceTLColor === Theme.YOUTUBE ? 'dark:text-translated-dark' : ''}`;
+
 </script>
 
+<!-- Comments absorb indentation whitespace that would leak between adjacent text runs.
+     The translate icon's visual gap is provided by margin on .material-icons in the style block. -->
 <span
   class={showTL ? translatedColor : ''}
-  class:cursor-pointer={translatedMessage}
-  class:entrance-animation={translatedMessage}
+  class:cursor-pointer={hasTranslation}
+  class:entrance-animation={hasTranslation}
   on:click={() => {
-    if (translatedMessage) {
+    if (hasTranslation) {
       showOriginal = !showOriginal;
       $refreshScroll = true;
     }
   }}
->
-  <span>
-    {showTL ? translatedMessage : text}
-  </span>
-
-  {#if translatedMessage}
-    <span class="shifted-icon">
-      <Icon xs={true} block={false}>
-        translate
-      </Icon>
-    </span>
-  {/if}
-</span>
+><!--
+-->{showTL ? translatedMessage : text}<!--
+-->{#if hasTranslation}<!--
+  --><span class="shifted-icon"><Icon xs={true} block={false}>translate</Icon></span><!--
+-->{/if}<!--
+--></span>
 
 <style>
   .shifted-icon  :global(.material-icons) {
     transform: translateY(1px);
+    margin: 0 0.25em;
   }
 </style>


### PR DESCRIPTION
The indentation/newline was being treated as actual whitespace, and I used HTML comments because putting it all on one line wasn't ideal and this is slightly more readable.

Also fix cases where it would treat translated text==original text as having a translation.

Should cherry-pick cleanly onto mv2.

Broken:
<img width="219" height="37" alt="Screenshot 2026-05-12 at 10 24 50 PM" src="https://github.com/user-attachments/assets/d7ad5598-c4eb-47ae-b88b-e513230e8826" />

Fixed:
<img width="213" height="36" alt="Screenshot 2026-05-12 at 10 24 22 PM" src="https://github.com/user-attachments/assets/fb5b2a8b-6318-4f1b-9448-e8bc34491cc5" />
