### PR TITLE
chore: merge mv3-ltl into main and mark it as retired

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,17 +4,16 @@
 
 - Make code changes on `mv2` first.
 - `main` is the real MV3 branch.
-- `mv3` is retired. Do not use it as the normal MV3 source branch for new work or cross-repo sync.
+- `mv3` and `mv3-ltl` are retired. Do not use them as MV3 source branches for new work or cross-repo sync; `main` is the MV3 line LiveTL consumes.
 - Do not implement feature/fix work directly on `main`.
 - If a task starts on another branch, switch to `mv2` before editing unless the user explicitly asks otherwise.
 - If a task touches both HyperChat and LiveTL, HyperChat still goes first.
 - Cross-repo order is mandatory:
   1. HyperChat `mv2`
   2. HyperChat `main`
-  3. HyperChat `mv3-ltl`
-  4. LiveTL `develop`
-  5. LiveTL `mv3-fr`
-  6. LiveTL `release`
+  3. LiveTL `develop`
+  4. LiveTL `mv3-fr`
+  5. LiveTL `release`
 - Never start cross-repo work in LiveTL when the HyperChat submodule also needs to change.
 - If the task also requires syncing YtcFilter (YTCF), do it after HyperChat `main` is updated:
   - merge HyperChat `main` into YTCF `master`
@@ -29,16 +28,14 @@
   - `order matters`
 - Avoid padded scopes, issue-number prefixes, and changelog-style essays in commit subjects.
 - A slightly dry or funny commit is fine if it is still clear at a glance.
-- Prefer proper merges when carrying `mv2` work into `main` and `mv3-ltl`.
-- Carry `main` into `mv3-ltl`. Do not treat `mv3` as the normal hop between them.
+- Prefer proper merges when carrying `mv2` work into `main`.
 - If MV3 needs follow-up adaptation, keep that as a small, explicit commit after the merge instead of rewriting history or hand-copying changes.
 
 ## Code Patterns
 
 - Prefer editing existing modules and utilities over creating one-off files for tiny helpers.
 - If a helper obviously belongs in an existing shared utility file, put it there.
-- Put shared behavior on `mv2` first; `main` and `mv3-ltl` should usually be merge-plus-adaptation branches, not separate feature branches.
-- Keep `mv3-ltl` branching from the current `main` line once `main` has the intended HC changes.
+- Put shared behavior on `mv2` first; `main` should usually be a merge-plus-adaptation branch, not a separate feature branch.
 - Keep MV3 adaptation narrow:
   - preserve branch-specific build/runtime wiring
   - change only what is required for manifest/background/injection differences

--- a/README.md
+++ b/README.md
@@ -61,3 +61,7 @@ VERSION=X.Y.Z npm run build:firefox # just Firefox
 ```
 
 The built ZIP files can be found in the `build` directory.
+
+## Release
+
+Release steps for `mv2` and `main` are documented in [RELEASE_PROCESS.md](./RELEASE_PROCESS.md).

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -8,10 +8,9 @@ This repo ships from two active lines that serve different purposes.
 2. Commit and push on `mv2`.
 3. Merge `mv2` into `main`.
 4. Validate and push `main`.
-5. If LiveTL needs the MV3-tailored HC line, merge `main` into `mv3-ltl`.
-6. Create releases from each branch that actually ships.
+5. Create releases from each branch that actually ships.
 
-`mv3` is historical. Do not route normal maintenance through `mv3` unless the user explicitly asks for branch archaeology.
+`main` is the MV3 line LiveTL consumes. `mv3` and `mv3-ltl` are historical. Do not route normal maintenance through them unless the user explicitly asks for branch archaeology.
 
 If the same task also affects LiveTL, do not begin in LiveTL. Finish this HyperChat ladder first, then bump the LiveTL submodule chain in this order:
 
@@ -74,4 +73,4 @@ Practical rule for `main`: bump `package.json`, commit it, then create/publish t
 
 ## Notes For LiveTL Sync
 
-LiveTL consumes HyperChat via submodules. Keep HyperChat changes branch-aligned across `mv2`, `main`, and `mv3-ltl` so LiveTL can take them with straightforward submodule bumps in its release flow.
+LiveTL consumes HyperChat via submodules. Keep HyperChat changes branch-aligned across `mv2` and `main` so LiveTL can take them with straightforward submodule bumps in its release flow. LiveTL's MV2 Firefox variant tracks `mv2`; its MV3 line tracks `main`.

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "build:firefox": "cross-env BROWSER=firefox vite build",
     "dev:chrome": "cross-env MINIFY=false BROWSER=chrome vite build --watch",
     "dev:firefox": "cross-env MINIFY=false BROWSER=firefox vite build --watch",
+    "start": "npm run dev:chrome",
+    "start:none": "npm run dev:chrome",
     "start:chrome": "cross-env AUTOLAUNCH=true npm run dev:chrome",
     "start:firefox": "cross-env AUTOLAUNCH=true npm run dev:firefox",
     "lint": "npm run lint:check -- --fix",

--- a/src/components/Message.svelte
+++ b/src/components/Message.svelte
@@ -16,6 +16,7 @@
   } from '../ts/storage';
   import { chatUserActionsItems, ChatUserActions, Theme } from '../ts/chat-constants';
   import { useBanHammer } from '../ts/chat-actions';
+  import type { Chat } from '../ts/typings/chat';
   import { formatAuthorName } from '../ts/component-utils';
   import { mdiGift, mdiReply } from '@mdi/js';
 

--- a/src/components/MessageRuns.svelte
+++ b/src/components/MessageRuns.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import { Theme, YoutubeEmojiRenderMode } from '../ts/chat-constants';
-
   import TranslatedMessage from './TranslatedMessage.svelte';
   import {
     emojiRenderMode, useSystemEmojis

--- a/src/scripts/chat-injector.ts
+++ b/src/scripts/chat-injector.ts
@@ -34,7 +34,7 @@ const ensureLiveTLTranslatorHost = (): void => {
 
   const script = document.createElement('script');
   script.id = 'hc-ltl-translator-host';
-  script.src = chrome.runtime.getURL('chat-translation-host.bundle.js');
+  script.src = getScriptURL('chat-translation-host.js');
   script.onload = () => script.remove();
   script.onerror = () => script.remove();
   (document.head ?? document.documentElement).appendChild(script);

--- a/src/ts/typings/ytc.d.ts
+++ b/src/ts/typings/ytc.d.ts
@@ -50,11 +50,7 @@ declare namespace Ytc {
       targetActionId: string;
     };
     addLiveChatTickerItemAction?: AddTickerAction;
-    updateLiveChatPollAction?: {
-      pollToUpdate: {
-        pollRenderer: PollRenderer;
-      };
-    };
+    updateLiveChatPollAction?: UpdatePollAction;
   }
 
   /** Expected YTC action object */
@@ -176,6 +172,12 @@ declare namespace Ytc {
 
   interface ThumbnailsWithLabel extends Thumbnails {
     accessibility?: AccessibilityObj;
+  }
+
+  interface UpdatePollAction {
+    pollToUpdate: {
+      pollRenderer: PollRenderer;
+    };
   }
 
   /** Message run object */
@@ -306,6 +308,19 @@ declare namespace Ytc {
         image: Thumbnails;
       };
     };
+  }
+
+  interface EngagementMessageRenderer {
+    message: RunsObj[];
+    id: string;
+    timestampUsec?: IntString;
+    icon?: {
+      /** Unlocalized string */
+      iconType: string;
+    };
+    actionButton?: {
+      buttonRenderer: ButtonRenderer;
+    }
   }
 
   interface ChatSummaryRenderer {


### PR DESCRIPTION
This was done before but it was brought back at some point accidentally.

Merging it in again and updating the agent instructions to reflect that. Will delete the `mv3-ltl` branch again afterwards.